### PR TITLE
Fix error using when eq/ord with mutual-rec type

### DIFF
--- a/src_plugins/ppx_deriving_eq.ml
+++ b/src_plugins/ppx_deriving_eq.ml
@@ -44,7 +44,7 @@ and expr_of_typ typ =
           | [], [] -> true
           | a :: x, b :: y -> [%e expr_of_typ typ] a b && loop x y
           | _ -> false
-        in loop]
+        in (fun x y -> loop x y)]
     | [%type: [%t? typ] array] ->
       [%expr fun x y ->
         let rec loop i =

--- a/src_plugins/ppx_deriving_ord.ml
+++ b/src_plugins/ppx_deriving_ord.ml
@@ -54,7 +54,7 @@ and expr_of_typ typ =
           | _, [] -> 1
           | a :: x, b :: y ->
             [%e compare_reduce [%expr loop x y] [%expr [%e expr_of_typ typ] a b]]
-        in loop]
+        in (fun x y -> loop x y)]
     | [%type: [%t? typ] array] ->
       [%expr fun x y ->
         let rec loop i =

--- a/src_test/test_deriving_eq.ml
+++ b/src_test/test_deriving_eq.ml
@@ -57,8 +57,23 @@ type 'a pt = { v : 'a } [@@deriving eq]
 let test_placeholder ctxt =
   assert_equal ~printer true ([%eq: _] 1 2)
 
+
+type mrec_variant =
+  | MrecFoo of string
+  | MrecBar of int
+
+and mrec_variant_list = mrec_variant list [@@deriving eq]
+
+let test_mrec ctxt =
+  assert_equal ~printer true  (equal_mrec_variant_list [MrecFoo "foo"; MrecBar 1]
+                                                       [MrecFoo "foo"; MrecBar 1]);
+  assert_equal ~printer false (equal_mrec_variant_list [MrecFoo "foo"; MrecBar 1]
+                                                       [MrecFoo "bar"; MrecBar 1])
+
 let suite = "Test deriving(eq)" >::: [
     "test_simple"       >:: test_simple;
     "test_custom"       >:: test_custom;
     "test_placeholder"  >:: test_placeholder;
+    "test_mrec"         >:: test_mrec;
   ]
+

--- a/src_test/test_deriving_ord.ml
+++ b/src_test/test_deriving_ord.ml
@@ -69,10 +69,27 @@ type 'a pt = { v : 'a } [@@deriving ord]
 let test_placeholder ctxt =
   assert_equal ~printer 0 ([%ord: _] 1 2)
 
+type mrec_variant =
+  | MrecFoo of string
+  | MrecBar of int
+
+and mrec_variant_list = mrec_variant list
+[@@deriving ord]
+
+let test_mrec ctxt =
+  assert_equal ~printer (0)   (compare_mrec_variant_list [MrecFoo "foo"; MrecBar 1;]
+                                                         [MrecFoo "foo"; MrecBar 1;]);
+  assert_equal ~printer (-1)  (compare_mrec_variant_list [MrecFoo "foo"; MrecBar 1;]
+                                                         [MrecFoo "foo"; MrecBar 2;]);
+  assert_equal ~printer (1)   (compare_mrec_variant_list [MrecFoo "foo"; MrecBar 2;]
+                                                         [MrecFoo "foo"; MrecBar 1;])
+
 let suite = "Test deriving(ord)" >::: [
     "test_simple"       >:: test_simple;
     "test_variant"      >:: test_variant;
     "test_complex"      >:: test_complex;
     "test_custom"       >:: test_custom;
     "test_placeholder"  >:: test_placeholder;
+    "test_mrec"         >:: test_mrec;
   ]
+


### PR DESCRIPTION
 - Add tests for mutual recursive type to  src_test/test_deriving_eq.ml,
   src_test/test_deriving_ord.ml
 - Fix code generation for list type in eq and ord plugin to avoid the
   error of 'let rec' restriction (This kind of expression is not
   allowed as right-hand side of `let rec')