### PR TITLE
Allow derivation of ord and show for mutually recursive types with polymorphic variable

### DIFF
--- a/src/ppx_deriving.ml
+++ b/src/ppx_deriving.ml
@@ -264,3 +264,8 @@ let seq_reduce ?sep a b =
 
 let binop_reduce x a b =
   [%expr [%e x] [%e a] [%e b]]
+
+let strong_type_of_type ty =
+  let free_vars = free_vars_in_core_type ty in
+  Typ.force_poly @@ Typ.poly free_vars ty
+

--- a/src/ppx_deriving.mli
+++ b/src/ppx_deriving.mli
@@ -236,3 +236,8 @@ val seq_reduce : ?sep:expression -> expression -> expression -> expression
 
 (** [binop_reduce] ≡ [fun x a b -> [%expr [%e x] [%e a] [%e b]]]. *)
 val binop_reduce : expression -> expression -> expression -> expression
+
+(** [strong_type_of_type ty] transform a type ty to 
+    [freevars . ty], giving a strong polymorph type *)
+val strong_type_of_type: core_type -> core_type
+

--- a/src_plugins/ppx_deriving_ord.ml
+++ b/src_plugins/ppx_deriving_ord.ml
@@ -156,10 +156,9 @@ let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
       raise_errorf ~loc "%s cannot be derived for open types" deriver
   in
   let polymorphize = Ppx_deriving.poly_fun_of_type_decl type_decl in
-  let weak_polymorph_function_type = core_type_of_decl ~options ~path type_decl in
-  let free_out_var = Ppx_deriving.free_vars_in_core_type weak_polymorph_function_type in
   let out_type =
-    Typ.force_poly @@ Typ.poly free_out_var @@ weak_polymorph_function_type in
+    Ppx_deriving.strong_type_of_type @@
+      core_type_of_decl ~options ~path type_decl in
   let out_var =
     pvar (Ppx_deriving.mangle_type_decl (`Prefix "compare") type_decl) in
   [Vb.mk (Pat.constraint_ out_var out_type)

--- a/src_plugins/ppx_deriving_ord.ml
+++ b/src_plugins/ppx_deriving_ord.ml
@@ -113,6 +113,17 @@ and expr_of_typ typ =
       raise_errorf ~loc:ptyp_loc "%s cannot be derived for %s"
                    deriver (Ppx_deriving.string_of_core_type typ)
 
+let core_type_of_decl ~options ~path type_decl =
+  parse_options options;
+  let typ = Ppx_deriving.core_type_of_type_decl type_decl in
+  let polymorphize = Ppx_deriving.poly_arrow_of_type_decl
+          (fun var -> [%type: [%t var] -> [%t var] -> int]) type_decl in
+  (polymorphize [%type: [%t typ] -> [%t typ] -> int])
+
+let sig_of_type ~options ~path type_decl =
+  [Sig.value (Val.mk (mknoloc (Ppx_deriving.mangle_type_decl (`Prefix "compare") type_decl))
+             (core_type_of_decl ~options ~path type_decl))]
+
 let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
   parse_options options;
   let comparator =
@@ -145,16 +156,14 @@ let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
       raise_errorf ~loc "%s cannot be derived for open types" deriver
   in
   let polymorphize = Ppx_deriving.poly_fun_of_type_decl type_decl in
-  [Vb.mk (pvar (Ppx_deriving.mangle_type_decl (`Prefix "compare") type_decl))
+  let weak_polymorph_function_type = core_type_of_decl ~options ~path type_decl in
+  let free_out_var = Ppx_deriving.free_vars_in_core_type weak_polymorph_function_type in
+  let out_type =
+    Typ.force_poly @@ Typ.poly free_out_var @@ weak_polymorph_function_type in
+  let out_var =
+    pvar (Ppx_deriving.mangle_type_decl (`Prefix "compare") type_decl) in
+  [Vb.mk (Pat.constraint_ out_var out_type)
          (polymorphize comparator)]
-
-let sig_of_type ~options ~path type_decl =
-  parse_options options;
-  let typ = Ppx_deriving.core_type_of_type_decl type_decl in
-  let polymorphize = Ppx_deriving.poly_arrow_of_type_decl
-          (fun var -> [%type: [%t var] -> [%t var] -> int]) type_decl in
-  [Sig.value (Val.mk (mknoloc (Ppx_deriving.mangle_type_decl (`Prefix "compare") type_decl))
-              (polymorphize [%type: [%t typ] -> [%t typ] -> int]))]
 
 let () =
   Ppx_deriving.(register (create deriver

--- a/src_plugins/ppx_deriving_show.ml
+++ b/src_plugins/ppx_deriving_show.ml
@@ -187,20 +187,13 @@ let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
                         (Ppx_deriving.mangle_type_decl (`Prefix "pp") type_decl)) in
   let stringprinter = [%expr fun x -> Format.asprintf "%a" [%e pp_poly_apply] x] in
   let polymorphize  = Ppx_deriving.poly_fun_of_type_decl type_decl in
-  let weak_polymorph_pp_type = pp_type_of_decl ~options ~path type_decl in
-  let weak_polymorph_show_type = show_type_of_decl ~options ~path type_decl in
-  (* the free var set should be the same in both types, but here
-   * we don't make any hypothesis. *)
-  let pp_free_var =
-    Ppx_deriving.free_vars_in_core_type weak_polymorph_pp_type in
-  let show_free_var =
-    Ppx_deriving.free_vars_in_core_type weak_polymorph_show_type in
+  let pp_type =
+    Ppx_deriving.strong_type_of_type @@ pp_type_of_decl ~options ~path type_decl in
+  let show_type =
+    Ppx_deriving.strong_type_of_type @@
+      show_type_of_decl ~options ~path type_decl in
   let pp_var =
     pvar (Ppx_deriving.mangle_type_decl (`Prefix "pp") type_decl) in
-  let pp_type =
-    Typ.force_poly @@ Typ.poly pp_free_var @@ weak_polymorph_pp_type in
-  let show_type =
-    Typ.force_poly @@ Typ.poly show_free_var @@ weak_polymorph_show_type in
   let show_var =
     pvar (Ppx_deriving.mangle_type_decl (`Prefix "show") type_decl) in
   [Vb.mk (Pat.constraint_ pp_var pp_type) (polymorphize prettyprinter);

--- a/src_test/test_deriving_eq.ml
+++ b/src_test/test_deriving_eq.ml
@@ -70,10 +70,25 @@ let test_mrec ctxt =
   assert_equal ~printer false (equal_mrec_variant_list [MrecFoo "foo"; MrecBar 1]
                                                        [MrecFoo "bar"; MrecBar 1])
 
+type e = Bool of be | Plus of e * e | IfE  of (be, e) if_e | Unit
+and be = True | False | And of be * be | IfB of (be, be) if_e
+and ('cond, 'a) if_e = 'cond * 'a * 'a
+  [@@deriving eq]
+
+let test_mut_rec ctxt =
+  let e1 = IfE (And (False, True), Unit, Plus (Unit, Unit)) in
+  let e2 = Plus (Unit, Bool False) in
+  assert_equal ~printer true (equal_e e1 e1);
+  assert_equal ~printer true (equal_e e2 e2);
+  assert_equal ~printer false (equal_e e1 e2);
+  assert_equal ~printer false (equal_e e2 e1)
+
+
 let suite = "Test deriving(eq)" >::: [
     "test_simple"       >:: test_simple;
     "test_custom"       >:: test_custom;
     "test_placeholder"  >:: test_placeholder;
     "test_mrec"         >:: test_mrec;
+    "test_mut_rec"      >:: test_mut_rec;
   ]
 

--- a/src_test/test_deriving_ord.ml
+++ b/src_test/test_deriving_ord.ml
@@ -41,6 +41,7 @@ let test_complex ctxt =
   assert_equal ~printer (-1) (compare_ty (0, "a") (0, "b"));
   assert_equal ~printer (1)  (compare_ty (0, "b") (0, "a"))
 
+
 type re = {
   f1 : int;
   f2 : string;
@@ -84,6 +85,20 @@ let test_mrec ctxt =
   assert_equal ~printer (1)   (compare_mrec_variant_list [MrecFoo "foo"; MrecBar 2;]
                                                          [MrecFoo "foo"; MrecBar 1;])
 
+
+type e = Bool of be | Plus of e * e | IfE  of (be, e) if_e
+and be = True | False | And of be * be | IfB of (be, be) if_e
+and ('cond, 'a) if_e = 'cond * 'a * 'a
+  [@@deriving ord]
+
+let test_mutualy_recursive ctxt =
+  let ce1 = Bool (IfB (True, False, True)) in
+  let ce2 = Bool (IfB (True, False, False)) in
+  assert_equal ~printer (0) (compare_e ce1 ce1);
+  assert_equal ~printer (-1) (compare_e ce1 ce2);
+  assert_equal ~printer (1) (compare_e ce2 ce1)
+
+
 let suite = "Test deriving(ord)" >::: [
     "test_simple"       >:: test_simple;
     "test_variant"      >:: test_variant;
@@ -91,5 +106,6 @@ let suite = "Test deriving(ord)" >::: [
     "test_custom"       >:: test_custom;
     "test_placeholder"  >:: test_placeholder;
     "test_mrec"         >:: test_mrec;
+    "test_mutualy_recursive" >:: test_mutualy_recursive;
   ]
 

--- a/src_test/test_deriving_show.ml
+++ b/src_test/test_deriving_show.ml
@@ -65,6 +65,7 @@ let test_record ctxt =
   assert_equal ~printer "{ Test_deriving_show.f1 = 1; f2 = \"foo\"; f3 = <opaque> }"
                         (show_re { f1 = 1; f2 = "foo"; f3 = 1.0 })
 
+
 module M : sig
   type t = A [@@deriving show]
 end = struct
@@ -123,6 +124,16 @@ end = struct
   type ('b,'a) t = 'b * 'a [@@deriving show]
 end
 
+
+type foo = F of int | B of int bar | C of float bar
+and 'a bar = { x : 'a ; r : foo } 
+  [@@deriving show]
+
+
+let test_mut_rec ctxt =
+  let e1 =  B { x = 12; r = F 16 } in
+  assert_equal ~printer "(Test_deriving_show.B\n   { Test_deriving_show.x = 12; r = (Test_deriving_show.F 16) })" (show_foo e1)
+
 let suite = "Test deriving(show)" >::: [
     "test_alias"        >:: test_alias;
     "test_variant"      >:: test_variant;
@@ -137,4 +148,5 @@ let suite = "Test deriving(show)" >::: [
     "test_alias_path"   >:: test_alias_path;
     "test_polypr"       >:: test_polypr;
     "test_placeholder"  >:: test_placeholder;
+    "test_mut_rec"      >:: test_mut_rec;
   ]


### PR DESCRIPTION
Related to whitequark/ppx_deriving#23

It works by adding a type signature to every generated function for both of these derivers, with strong polymorphic constraint.