### PR TITLE
Simplifying generated code for ord

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ The function `fprintf` is locally defined in the printer.
 Plugins: eq and ord
 -------------------
 
-_eq_ derives a function comparing values by semantic equality; structural or physical depending on context. _ord_ derives a function defining a total order for values, returning `-1`, `0` or `1`. They're similar to `Pervasives.(=)` and `Pervasives.compare`, but are faster, allow to customize the comparison rules, and never raise at runtime. _eq_ and _ord_ are short-circuiting.
+_eq_ derives a function comparing values by semantic equality; structural or physical depending on context. _ord_ derives a function defining a total order for values, returning a negative value if lower, `0` if equal or a positive value is greater. They're similar to `Pervasives.(=)` and `Pervasives.compare`, but are faster, allow to customize the comparison rules, and never raise at runtime. _eq_ and _ord_ are short-circuiting.
 
 ``` ocaml
 # type t = [ `A | `B of int ] [@@deriving eq, ord];;


### PR DESCRIPTION
Currently the generated code for ord looks like that:
~~~~{ocaml}
type v =
  | Foo
  | Bar of int* string
  | Baz of string
  [@@deriving ord]

let rec compare_v : v -> v -> int=
  fun lhs  ->
    fun rhs  ->
      match (lhs, rhs) with
      | (Foo ,Foo ) -> 0
      | (Bar (lhs0,lhs1),Bar (rhs0,rhs1)) ->
          (match (fun (a : int)  -> fun b  -> Pervasives.compare a b) lhs0
                   rhs0
           with
           | (-1)|1 as x -> x
           | _ ->
               (match (fun (a : string)  -> fun b  -> Pervasives.compare a b)
                        lhs1 rhs1
                with
                | (-1)|1 as x -> x
                | _ -> 0))
      | (Baz lhs0,Baz rhs0) ->
          (match (fun (a : string)  -> fun b  -> Pervasives.compare a b) lhs0
                   rhs0
           with
           | (-1)|1 as x -> x
           | _ -> 0)
      | _ ->
          let to_int = function | Foo  -> 0 | Bar (_,_) -> 1 | Baz _ -> 2 in
          ((fun (a : int)  -> fun b  -> Pervasives.compare a b)) (to_int lhs)
            (to_int rhs)
~~~~

With this patch, it looks like the following.

~~~~{ocaml}
let rec compare_v : v -> v -> int=
  fun lhs  ->
    fun rhs  ->
      match (lhs, rhs) with
      | (Foo ,Foo ) -> 0
      | (Bar (lhs0,lhs1),Bar (rhs0,rhs1)) ->
          (match Pervasives.compare lhs0 rhs0 with
           | 0 -> Pervasives.compare lhs1 rhs1
           | x -> x)
      | (Baz lhs0,Baz rhs0) -> Pervasives.compare lhs0 rhs0
      | _ ->
          let to_int = function | Foo  -> 0 | Bar (_,_) -> 1 | Baz _ -> 2 in
          Pervasives.compare (to_int lhs) (to_int rhs)
~~~~

The first big difference is the removal of an unneeded last match
case, coming from a fold_left use, and replaced by a `reduce_compare`
function taking the first expression as base case.

Thus, this snippets:

~~~~{ocaml}
(match (fun (a : string)  -> fun b  -> Pervasives.compare a b) lhs0
         rhs0
 with
 | (-1)|1 as x -> x
 | _ -> 0)
~~~~

Becomes

~~~~{ocaml}
(fun (a : string)  -> fun b  -> Pervasives.compare a b) lhs0 rhs0
~~~~

The second optimisation is to eta-reduce all the call to
Pervasives.compare, as their types are well known by the compiler,
they don't bring anything to the table. The previous example become

~~~~{ocaml}
Pervasives.compare lhs0 rhs0
~~~~

Finally, there is a change in the comparison operator:

~~~~{ocaml}
match %e with
| (-1|1) as x -> x
| _ -> %rest
~~~~

is transformed to

~~~~{ocaml}
match %e with
| 0 -> %rest
| x -> x
~~~~

This is due to the fact that the Pervasives.compare function doesn't
guarantee you to obtain `(-1|1)` as output value if you're greater or
lower, but a negative or positive number. Only the equality case is
specified, being 0, so it's safer to match against it when we're calling
non-derived comparison functions. This change affect the documentation
in the README stating that the function return -1, 0 or 1.

