### PR TITLE
Adding handling of shadowed standard types in mutually recursive types.

### DIFF
--- a/src/ppx_deriving.mli
+++ b/src/ppx_deriving.mli
@@ -2,6 +2,8 @@
 
 open Parsetree
 
+module StringSet : Set.S with type elt = string
+
 (** {2 Registration} *)
 
 (** A type of deriving plugins.
@@ -240,4 +242,11 @@ val binop_reduce : expression -> expression -> expression -> expression
 (** [strong_type_of_type ty] transform a type ty to 
     [freevars . ty], giving a strong polymorphic type *)
 val strong_type_of_type: core_type -> core_type
+
+(** [extract_typename_of_type_group ~allow_shadowing tys] will extract
+    the set of all types in a type group. Will raise an error in case
+    of type shadowing standard types, unless [~allow_shadowing] is set
+    to true. *)
+val extract_typename_of_type_group : string -> allow_shadowing:bool ->
+                                     type_declaration list -> StringSet.t
 

--- a/src_plugins/ppx_deriving_eq.ml
+++ b/src_plugins/ppx_deriving_eq.ml
@@ -12,18 +12,18 @@ let raise_errorf = Ppx_deriving.raise_errorf
 
 type eq_options =
   {
-    allow_std_type_masking: bool;
+    allow_std_type_shadowing: bool;
   }
 
 let default_eq_options =
   {
-    allow_std_type_masking = false;
+    allow_std_type_shadowing= false;
   }
 
 let parse_options options =
   let option_parser acc (name, expr) =
     match name with
-    | "allow_std_type_masking" -> { allow_std_type_masking = true }
+    | "allow_std_type_shadowing" -> { allow_std_type_shadowing = true }
     | _ ->
       raise_errorf ~loc:expr.pexp_loc "%s does not support option %s" deriver name in
   List.fold_left option_parser default_eq_options options
@@ -162,7 +162,7 @@ let type_decl_str ~options ~path type_decls =
   let typename_set =
     Ppx_deriving.extract_typename_of_type_group 
       deriver
-      ~allow_shadowing:opts.allow_std_type_masking
+      ~allow_shadowing:opts.allow_std_type_shadowing
       type_decls in
   let here_loc = (List.hd type_decls).ptype_loc in
   if StringSet.mem "bool" typename_set then

--- a/src_plugins/ppx_deriving_eq.ml
+++ b/src_plugins/ppx_deriving_eq.ml
@@ -5,13 +5,28 @@ open Parsetree
 open Ast_helper
 open Ast_convenience
 
+module StringSet = Ppx_deriving.StringSet
+
 let deriver = "eq"
 let raise_errorf = Ppx_deriving.raise_errorf
 
+type eq_options =
+  {
+    allow_std_type_masking: bool;
+  }
+
+let default_eq_options =
+  {
+    allow_std_type_masking = false;
+  }
+
 let parse_options options =
-  options |> List.iter (fun (name, expr) ->
+  let option_parser acc (name, expr) =
     match name with
-    | _ -> raise_errorf ~loc:expr.pexp_loc "%s does not support option %s" deriver name)
+    | "allow_std_type_masking" -> { allow_std_type_masking = true }
+    | _ ->
+      raise_errorf ~loc:expr.pexp_loc "%s does not support option %s" deriver name in
+  List.fold_left option_parser default_eq_options options
 
 let attr_equal attrs =
   Ppx_deriving.(attrs |> attr ~deriver "equal" |> Arg.(get_attr ~deriver expr))
@@ -23,58 +38,62 @@ let pattn side typs =
   List.mapi (fun i _ -> pvar (argn side i)) typs
 
 let core_type_of_decl ~options ~path type_decl =
-  parse_options options;
+  ignore (parse_options options);
   let typ = Ppx_deriving.core_type_of_type_decl type_decl in
   Ppx_deriving.poly_arrow_of_type_decl
-    (fun var -> [%type: [%t var] -> [%t var] -> bool])
+    (fun var -> [%type: [%t var] -> [%t var] -> Pervasives.bool])
     type_decl
-    [%type: [%t typ] -> [%t typ] -> bool]
+    [%type: [%t typ] -> [%t typ] -> Pervasives.bool]
 
 let sig_of_type ~options ~path type_decl =
-  parse_options options;
+  ignore (parse_options options);
   [Sig.value (Val.mk (mknoloc (Ppx_deriving.mangle_type_decl (`Prefix "equal") type_decl))
              (core_type_of_decl ~options ~path type_decl))]
 
-let rec exprsn typs =
+let rec exprsn group_def typs =
   typs |> List.mapi (fun i typ ->
-    app (expr_of_typ typ) [evar (argn `lhs i); evar (argn `rhs i)])
+    app (expr_of_typ group_def typ) [evar (argn `lhs i); evar (argn `rhs i)])
 
-and expr_of_typ typ =
+and expr_of_typ group_def typ =
   match attr_equal typ.ptyp_attributes with
   | Some fn -> fn
   | None ->
     match typ with
+    | { ptyp_desc = Ptyp_constr ({ txt = (Lident id as lid) }, args) } 
+        when StringSet.mem id group_def ->
+      let equal_fn = Exp.ident (mknoloc (Ppx_deriving.mangle_lid (`Prefix "equal") lid)) in
+      app equal_fn (List.map (expr_of_typ group_def) args)
     | [%type: _] | [%type: unit] -> [%expr fun _ _ -> true]
     | [%type: int] | [%type: int32] | [%type: Int32.t]
     | [%type: int64] | [%type: Int64.t] | [%type: nativeint] | [%type: Nativeint.t]
     | [%type: float] | [%type: bool] | [%type: char] | [%type: string] | [%type: bytes] ->
       [%expr (fun (a:[%t typ]) b -> a = b)]
-    | [%type: [%t? typ] ref]   -> [%expr fun a b -> [%e expr_of_typ typ] !a !b]
+    | [%type: [%t? typ] ref]   -> [%expr fun a b -> [%e expr_of_typ group_def typ] !a !b]
     | [%type: [%t? typ] list]  ->
       [%expr
         let rec loop x y =
           match x, y with
           | [], [] -> true
-          | a :: x, b :: y -> [%e expr_of_typ typ] a b && loop x y
+          | a :: x, b :: y -> [%e expr_of_typ group_def typ] a b && loop x y
           | _ -> false
         in (fun x y -> loop x y)]
     | [%type: [%t? typ] array] ->
       [%expr fun x y ->
         let rec loop i =
-          (i = Array.length x || [%e expr_of_typ typ] x.(i) y.(i)) && loop (i + 1)
+          (i = Array.length x || [%e expr_of_typ group_def typ] x.(i) y.(i)) && loop (i + 1)
         in Array.length x = Array.length y && loop 0]
     | [%type: [%t? typ] option] ->
       [%expr fun x y ->
         match x, y with
         | None, None -> true
-        | Some a, Some b -> [%e expr_of_typ typ] a b
+        | Some a, Some b -> [%e expr_of_typ group_def typ] a b
         | _ -> false]
     | { ptyp_desc = Ptyp_constr ({ txt = lid }, args) } ->
       let equal_fn = Exp.ident (mknoloc (Ppx_deriving.mangle_lid (`Prefix "equal") lid)) in
-      app equal_fn (List.map expr_of_typ args)
+      app equal_fn (List.map (expr_of_typ group_def) args)
     | { ptyp_desc = Ptyp_tuple typs } ->
       [%expr fun [%p ptuple (pattn `lhs typs)] [%p ptuple (pattn `rhs typs)] ->
-        [%e exprsn typs |> Ppx_deriving.(fold_exprs (binop_reduce [%expr (&&)]))]]
+        [%e exprsn group_def typs |> Ppx_deriving.(fold_exprs (binop_reduce [%expr (&&)]))]]
     | { ptyp_desc = Ptyp_variant (fields, _, _); ptyp_loc } ->
       let cases =
         (fields |> List.map (fun field ->
@@ -84,10 +103,10 @@ and expr_of_typ typ =
             Exp.case (pdup (fun _ -> Pat.variant label None)) [%expr true]
           | Rtag (label, _, false, [typ]) ->
             Exp.case (pdup (fun var -> Pat.variant label (Some (pvar var))))
-                     (app (expr_of_typ typ) [evar "lhs"; evar "rhs"])
+                     (app (expr_of_typ group_def typ) [evar "lhs"; evar "rhs"])
           | Rinherit ({ ptyp_desc = Ptyp_constr (tname, _) } as typ) ->
             Exp.case (pdup (fun var -> Pat.alias (Pat.type_ tname) (mknoloc var)))
-                     (app (expr_of_typ typ) [evar "lhs"; evar "rhs"])
+                     (app (expr_of_typ group_def typ) [evar "lhs"; evar "rhs"])
           | _ ->
             raise_errorf ~loc:ptyp_loc "%s cannot be derived for %s"
                          deriver (Ppx_deriving.string_of_core_type typ))) @
@@ -95,31 +114,33 @@ and expr_of_typ typ =
       in
       [%expr fun lhs rhs -> [%e Exp.match_ [%expr lhs, rhs] cases]]
     | { ptyp_desc = Ptyp_var name } -> evar ("poly_"^name)
-    | { ptyp_desc = Ptyp_alias (typ, _) } -> expr_of_typ typ
+    | { ptyp_desc = Ptyp_alias (typ, _) } -> expr_of_typ group_def typ
     | { ptyp_loc } ->
       raise_errorf ~loc:ptyp_loc "%s cannot be derived for %s"
                    deriver (Ppx_deriving.string_of_core_type typ)
 
-let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
-  parse_options options;
+let str_of_type ~options ~path group_def ({ ptype_loc = loc } as type_decl) =
+  ignore (parse_options options);
   let comparator =
     match type_decl.ptype_kind, type_decl.ptype_manifest with
-    | Ptype_abstract, Some manifest -> expr_of_typ manifest
+    | Ptype_abstract, Some manifest -> expr_of_typ group_def manifest
     | Ptype_variant constrs, _ ->
+      let wildcard = match constrs with
+        | [] | [_] -> []
+        | _ :: _ :: _ -> [Exp.case (pvar "_") [%expr false]] in
       let cases =
         (constrs |> List.map (fun { pcd_name = { txt = name }; pcd_args = typs } ->
-          exprsn typs |>
+          exprsn group_def typs |>
           Ppx_deriving.(fold_exprs ~unit:[%expr true] (binop_reduce [%expr (&&)])) |>
           Exp.case (ptuple [pconstr name (pattn `lhs typs);
-                            pconstr name (pattn `rhs typs)]))) @
-        [Exp.case (pvar "_") [%expr false]]
+                            pconstr name (pattn `rhs typs)]))) @ wildcard 
       in
       [%expr fun lhs rhs -> [%e Exp.match_ [%expr lhs, rhs] cases]]
     | Ptype_record labels, _ ->
       let exprs =
         labels |> List.map (fun { pld_name = { txt = name }; pld_type } ->
           let field obj = Exp.field obj (mknoloc (Lident name)) in
-          app (expr_of_typ pld_type) [field (evar "lhs"); field (evar "rhs")])
+          app (expr_of_typ group_def pld_type) [field (evar "lhs"); field (evar "rhs")])
       in
       [%expr fun lhs rhs -> [%e exprs |> Ppx_deriving.(fold_exprs (binop_reduce [%expr (&&)]))]]
     | Ptype_abstract, None ->
@@ -135,11 +156,21 @@ let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
     pvar (Ppx_deriving.mangle_type_decl (`Prefix "equal") type_decl) in
   [Vb.mk (Pat.constraint_ eq_var out_type) (polymorphize comparator)]
 
+let type_decl_str ~options ~path type_decls =
+  let opts = parse_options options in
+  let typename_set =
+    Ppx_deriving.extract_typename_of_type_group 
+      deriver
+      ~allow_shadowing:opts.allow_std_type_masking
+      type_decls in
+  let code =
+    List.map (str_of_type ~options ~path typename_set) type_decls in
+  [Str.value Recursive (List.concat code)]
+
 let () =
-  Ppx_deriving.(register (create "eq"
-    ~core_type: expr_of_typ
-    ~type_decl_str: (fun ~options ~path type_decls ->
-       [Str.value Recursive (List.concat (List.map (str_of_type ~options ~path) type_decls))])
+  Ppx_deriving.(register (create deriver
+    ~core_type:(expr_of_typ StringSet.empty)
+    ~type_decl_str: type_decl_str
     ~type_decl_sig: (fun ~options ~path type_decls ->
        List.concat (List.map (sig_of_type ~options ~path) type_decls))
     ()

--- a/src_plugins/ppx_deriving_ord.ml
+++ b/src_plugins/ppx_deriving_ord.ml
@@ -200,6 +200,11 @@ let type_decl_str ~options ~path type_decls =
       deriver
       ~allow_shadowing:opts.allow_std_type_masking
       type_decls in
+  let here_loc = (List.hd type_decls).ptype_loc in
+  if StringSet.mem "int" typename_set then
+    raise_errorf
+      ~loc:here_loc
+      "%s can't derivate types when shadowing int (even with option)" deriver;
   let code =
     List.map (str_of_type ~options ~path typename_set) type_decls in
   [Str.value Recursive (List.concat code)]

--- a/src_plugins/ppx_deriving_ord.ml
+++ b/src_plugins/ppx_deriving_ord.ml
@@ -5,13 +5,28 @@ open Parsetree
 open Ast_helper
 open Ast_convenience
 
+module StringSet = Ppx_deriving.StringSet
+
 let deriver = "ord"
 let raise_errorf = Ppx_deriving.raise_errorf
 
+type ord_options =
+  {
+    allow_std_type_masking: bool;
+  }
+
+let default_ord_options =
+  {
+    allow_std_type_masking = false;
+  }
+
 let parse_options options =
-  options |> List.iter (fun (name, expr) ->
+  let option_parser acc (name, expr) =
     match name with
-    | _ -> raise_errorf ~loc:expr.pexp_loc "%s does not support option %s" deriver name)
+    | "allow_std_type_masking" -> { allow_std_type_masking = true }
+    | _ ->
+      raise_errorf ~loc:expr.pexp_loc "%s does not support option %s" deriver name in
+  List.fold_left option_parser default_ord_options options
 
 let attr_compare attrs =
   Ppx_deriving.(attrs |> attr ~deriver "compare" |> Arg.(get_attr ~deriver expr))
@@ -34,91 +49,98 @@ let wildcard_case int_cases =
 let pattn side typs =
   List.mapi (fun i _ -> pvar (argn side i)) typs
 
-let rec exprsn typs =
+let rec exprsn group_def typs =
   typs |> List.mapi (fun i typ ->
-    app (expr_of_typ typ) [evar (argn `lhs i); evar (argn `rhs i)])
+    app (expr_of_typ group_def typ) [evar (argn `lhs i); evar (argn `rhs i)])
 
-and expr_of_typ typ =
-  match attr_compare typ.ptyp_attributes with
-  | Some fn -> fn
-  | None ->
-    match typ with
-    | [%type: _] | [%type: unit] -> [%expr fun _ _ -> 0]
-    | [%type: int] | [%type: int32] | [%type: Int32.t]
-    | [%type: int64] | [%type: Int64.t] | [%type: nativeint] | [%type: Nativeint.t]
-    | [%type: float] | [%type: bool] | [%type: char] | [%type: string] | [%type: bytes] ->
-      [%expr Pervasives.compare]
-    | [%type: [%t? typ] ref]   -> [%expr fun a b -> [%e expr_of_typ typ] !a !b]
-    | [%type: [%t? typ] list]  ->
-      [%expr
-        let rec loop x y =
+and expr_of_typ group_def typ =
+  let rec aux typ =
+    match attr_compare typ.ptyp_attributes with
+    | Some fn -> fn
+    | None ->
+      match typ with
+      | { ptyp_desc = Ptyp_constr ({ txt = (Lident id as lid) }, args) } when
+            StringSet.mem id group_def ->
+        let compare_fn = Exp.ident (mknoloc (Ppx_deriving.mangle_lid (`Prefix "compare") lid)) in
+        app compare_fn (List.map aux args)
+      | [%type: _] | [%type: unit] -> [%expr fun _ _ -> 0]
+      | [%type: int] | [%type: int32] | [%type: Int32.t]
+      | [%type: int64] | [%type: Int64.t] | [%type: nativeint] | [%type: Nativeint.t]
+      | [%type: float] | [%type: bool] | [%type: char] | [%type: string] | [%type: String.t] |
+        [%type: bytes] ->
+        [%expr Pervasives.compare]
+      | [%type: [%t? typ] ref]   -> [%expr fun a b -> [%e aux typ] !a !b]
+      | [%type: [%t? typ] list]  ->
+        [%expr
+          let rec loop x y =
+            match x, y with
+            | [], [] -> 0
+            | [], _ -> -1
+            | _, [] -> 1
+            | a :: x, b :: y ->
+              [%e compare_reduce [%expr loop x y] [%expr [%e aux typ] a b]]
+          in (fun x y -> loop x y)]
+      | [%type: [%t? typ] array] ->
+        [%expr fun x y ->
+          let rec loop i =
+            if i = Array.length x then 0
+            else [%e compare_reduce [%expr loop (i + 1)]
+                                    [%expr [%e aux typ] x.(i) y.(i)]]
+          in
+          [%e compare_reduce [%expr loop 0]
+                             [%expr Pervasives.compare (Array.length x) (Array.length y)]]]
+      | [%type: [%t? typ] option] ->
+        [%expr fun x y ->
           match x, y with
-          | [], [] -> 0
-          | [], _ -> -1
-          | _, [] -> 1
-          | a :: x, b :: y ->
-            [%e compare_reduce [%expr loop x y] [%expr [%e expr_of_typ typ] a b]]
-        in (fun x y -> loop x y)]
-    | [%type: [%t? typ] array] ->
-      [%expr fun x y ->
-        let rec loop i =
-          if i = Array.length x then 0
-          else [%e compare_reduce [%expr loop (i + 1)]
-                                  [%expr [%e expr_of_typ typ] x.(i) y.(i)]]
+          | None, None -> 0
+          | Some a, Some b -> [%e aux typ] a b
+          | None, Some _ -> -1
+          | Some _, None -> 1]
+      | { ptyp_desc = Ptyp_constr ({ txt = lid }, args) } ->
+        let compare_fn = Exp.ident (mknoloc (Ppx_deriving.mangle_lid (`Prefix "compare") lid)) in
+        app compare_fn (List.map aux args)
+      | { ptyp_desc = Ptyp_tuple typs } ->
+        [%expr fun [%p ptuple (pattn `lhs typs)] [%p ptuple (pattn `rhs typs)] ->
+          [%e exprsn group_def typs |> List.rev |> reduce_compare]]
+      | { ptyp_desc = Ptyp_variant (fields, _, _); ptyp_loc } ->
+        let cases =
+          fields |> List.map (fun field ->
+            let pdup f = ptuple [f "lhs"; f "rhs"] in
+            match field with
+            | Rtag (label, _, true (*empty*), []) ->
+              Exp.case (pdup (fun _ -> Pat.variant label None)) [%expr 0]
+            | Rtag (label, _, false, [typ]) ->
+              Exp.case (pdup (fun var -> Pat.variant label (Some (pvar var))))
+                       (app (aux typ) [evar "lhs"; evar "rhs"])
+            | Rinherit ({ ptyp_desc = Ptyp_constr (tname, _) } as typ) ->
+              Exp.case (pdup (fun var -> Pat.alias (Pat.type_ tname) (mknoloc var)))
+                       (app (aux typ) [evar "lhs"; evar "rhs"])
+            | _ ->
+              raise_errorf ~loc:ptyp_loc "%s cannot be derived for %s"
+                           deriver (Ppx_deriving.string_of_core_type typ))
         in
-        [%e compare_reduce [%expr loop 0]
-                           [%expr Pervasives.compare (Array.length x) (Array.length y)]]]
-    | [%type: [%t? typ] option] ->
-      [%expr fun x y ->
-        match x, y with
-        | None, None -> 0
-        | Some a, Some b -> [%e expr_of_typ typ] a b
-        | None, Some _ -> -1
-        | Some _, None -> 1]
-    | { ptyp_desc = Ptyp_constr ({ txt = lid }, args) } ->
-      let compare_fn = Exp.ident (mknoloc (Ppx_deriving.mangle_lid (`Prefix "compare") lid)) in
-      app compare_fn (List.map expr_of_typ args)
-    | { ptyp_desc = Ptyp_tuple typs } ->
-      [%expr fun [%p ptuple (pattn `lhs typs)] [%p ptuple (pattn `rhs typs)] ->
-        [%e exprsn typs |> List.rev |> reduce_compare]]
-    | { ptyp_desc = Ptyp_variant (fields, _, _); ptyp_loc } ->
-      let cases =
-        fields |> List.map (fun field ->
-          let pdup f = ptuple [f "lhs"; f "rhs"] in
-          match field with
-          | Rtag (label, _, true (*empty*), []) ->
-            Exp.case (pdup (fun _ -> Pat.variant label None)) [%expr 0]
-          | Rtag (label, _, false, [typ]) ->
-            Exp.case (pdup (fun var -> Pat.variant label (Some (pvar var))))
-                     (app (expr_of_typ typ) [evar "lhs"; evar "rhs"])
-          | Rinherit ({ ptyp_desc = Ptyp_constr (tname, _) } as typ) ->
-            Exp.case (pdup (fun var -> Pat.alias (Pat.type_ tname) (mknoloc var)))
-                     (app (expr_of_typ typ) [evar "lhs"; evar "rhs"])
-          | _ ->
-            raise_errorf ~loc:ptyp_loc "%s cannot be derived for %s"
-                         deriver (Ppx_deriving.string_of_core_type typ))
-      in
-      let int_cases =
-        fields |> List.mapi (fun i field ->
-          match field with
-          | Rtag (label, _, true (*empty*), []) ->
-            Exp.case (Pat.variant label None) (int i)
-          | Rtag (label, _, false, [typ]) ->
-            Exp.case (Pat.variant label (Some [%pat? _])) (int i)
-          | Rinherit { ptyp_desc = Ptyp_constr (tname, []) } ->
-            Exp.case (Pat.type_ tname) (int i)
-          | _ -> assert false)
-      in
-      [%expr fun lhs rhs ->
-        [%e Exp.match_ [%expr lhs, rhs] (cases @ [wildcard_case int_cases])]]
-    | { ptyp_desc = Ptyp_var name } -> evar ("poly_"^name)
-    | { ptyp_desc = Ptyp_alias (typ, _) } -> expr_of_typ typ
-    | { ptyp_loc } ->
-      raise_errorf ~loc:ptyp_loc "%s cannot be derived for %s"
-                   deriver (Ppx_deriving.string_of_core_type typ)
+        let int_cases =
+          fields |> List.mapi (fun i field ->
+            match field with
+            | Rtag (label, _, true (*empty*), []) ->
+              Exp.case (Pat.variant label None) (int i)
+            | Rtag (label, _, false, [typ]) ->
+              Exp.case (Pat.variant label (Some [%pat? _])) (int i)
+            | Rinherit { ptyp_desc = Ptyp_constr (tname, []) } ->
+              Exp.case (Pat.type_ tname) (int i)
+            | _ -> assert false)
+        in
+        [%expr fun lhs rhs ->
+          [%e Exp.match_ [%expr lhs, rhs] (cases @ [wildcard_case int_cases])]]
+      | { ptyp_desc = Ptyp_var name } -> evar ("poly_"^name)
+      | { ptyp_desc = Ptyp_alias (typ, _) } -> aux typ
+      | { ptyp_loc } ->
+        raise_errorf ~loc:ptyp_loc "%s cannot be derived for %s"
+                     deriver (Ppx_deriving.string_of_core_type typ) in
+  aux typ
 
 let core_type_of_decl ~options ~path type_decl =
-  parse_options options;
+  ignore (parse_options options);
   let typ = Ppx_deriving.core_type_of_type_decl type_decl in
   let polymorphize = Ppx_deriving.poly_arrow_of_type_decl
           (fun var -> [%type: [%t var] -> [%t var] -> int]) type_decl in
@@ -128,11 +150,11 @@ let sig_of_type ~options ~path type_decl =
   [Sig.value (Val.mk (mknoloc (Ppx_deriving.mangle_type_decl (`Prefix "compare") type_decl))
              (core_type_of_decl ~options ~path type_decl))]
 
-let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
-  parse_options options;
+let str_of_type ~options ~path group_def ({ ptype_loc = loc } as type_decl) =
+  ignore (parse_options options);
   let comparator =
     match type_decl.ptype_kind, type_decl.ptype_manifest with
-    | Ptype_abstract, Some manifest -> expr_of_typ manifest
+    | Ptype_abstract, Some manifest -> expr_of_typ group_def manifest
     | Ptype_variant constrs, _ ->
       let int_cases =
           constrs |> List.mapi (fun i { pcd_name = { txt = name }; pcd_args } ->
@@ -141,7 +163,7 @@ let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
             | _  -> Exp.case (pconstr name (List.map (fun _ -> [%pat? _]) pcd_args)) (int i))
       and cases =
         constrs |> List.map (fun { pcd_name = { txt = name }; pcd_args = typs } ->
-          exprsn typs |> List.rev |> reduce_compare |>
+          exprsn group_def typs |> List.rev |> reduce_compare |>
           Exp.case (ptuple [pconstr name (pattn `lhs typs);
                             pconstr name (pattn `rhs typs)]))
       in
@@ -151,7 +173,7 @@ let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
       let exprs =
         labels |> List.map (fun { pld_name = { txt = name }; pld_type } ->
           let field obj = Exp.field obj (mknoloc (Lident name)) in
-          app (expr_of_typ pld_type) [field (evar "lhs"); field (evar "rhs")])
+          app (expr_of_typ group_def pld_type) [field (evar "lhs"); field (evar "rhs")])
       in
       [%expr fun lhs rhs -> [%e reduce_compare exprs]]
     | Ptype_abstract, None ->
@@ -168,11 +190,21 @@ let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
   [Vb.mk (Pat.constraint_ out_var out_type)
          (polymorphize comparator)]
 
+let type_decl_str ~options ~path type_decls =
+  let opts = parse_options options in
+  let typename_set =
+    Ppx_deriving.extract_typename_of_type_group 
+      deriver
+      ~allow_shadowing:opts.allow_std_type_masking
+      type_decls in
+  let code =
+    List.map (str_of_type ~options ~path typename_set) type_decls in
+  [Str.value Recursive (List.concat code)]
+
 let () =
   Ppx_deriving.(register (create deriver
-    ~core_type: expr_of_typ
-    ~type_decl_str: (fun ~options ~path type_decls ->
-      [Str.value Recursive (List.concat (List.map (str_of_type ~options ~path) type_decls))])
+    ~core_type: (expr_of_typ StringSet.empty)
+    ~type_decl_str: type_decl_str
     ~type_decl_sig: (fun ~options ~path type_decls ->
       List.concat (List.map (sig_of_type ~options ~path) type_decls))
     ()

--- a/src_plugins/ppx_deriving_ord.ml
+++ b/src_plugins/ppx_deriving_ord.ml
@@ -12,18 +12,18 @@ let raise_errorf = Ppx_deriving.raise_errorf
 
 type ord_options =
   {
-    allow_std_type_masking: bool;
+    allow_std_type_shadowing: bool;
   }
 
 let default_ord_options =
   {
-    allow_std_type_masking = false;
+    allow_std_type_shadowing = false;
   }
 
 let parse_options options =
   let option_parser acc (name, expr) =
     match name with
-    | "allow_std_type_masking" -> { allow_std_type_masking = true }
+    | "allow_std_type_shadowing" -> { allow_std_type_shadowing = true }
     | _ ->
       raise_errorf ~loc:expr.pexp_loc "%s does not support option %s" deriver name in
   List.fold_left option_parser default_ord_options options
@@ -198,7 +198,7 @@ let type_decl_str ~options ~path type_decls =
   let typename_set =
     Ppx_deriving.extract_typename_of_type_group 
       deriver
-      ~allow_shadowing:opts.allow_std_type_masking
+      ~allow_shadowing:opts.allow_std_type_shadowing
       type_decls in
   let here_loc = (List.hd type_decls).ptype_loc in
   if StringSet.mem "int" typename_set then

--- a/src_plugins/ppx_deriving_show.ml
+++ b/src_plugins/ppx_deriving_show.ml
@@ -12,18 +12,18 @@ let raise_errorf = Ppx_deriving.raise_errorf
 
 type show_options =
   {
-    allow_std_type_masking: bool;
+    allow_std_type_shadowing: bool;
   }
 
 let default_show_options =
   {
-    allow_std_type_masking = false;
+    allow_std_type_shadowing = false;
   }
 
 let parse_options options =
   let option_parser acc (name, expr) =
     match name with
-    | "allow_std_type_masking" -> { allow_std_type_masking = true }
+    | "allow_std_type_shadowing" -> { allow_std_type_shadowing = true }
     | _ ->
       raise_errorf ~loc:expr.pexp_loc "%s does not support option %s" deriver name in
   List.fold_left option_parser default_show_options options
@@ -222,7 +222,7 @@ let type_decl_str ~options ~path type_decls =
   let typename_set =
     Ppx_deriving.extract_typename_of_type_group 
       deriver
-      ~allow_shadowing:opts.allow_std_type_masking
+      ~allow_shadowing:opts.allow_std_type_shadowing
       type_decls in
   let code =
     List.map (str_of_type ~options ~path typename_set) type_decls in

--- a/src_plugins/ppx_deriving_show.ml
+++ b/src_plugins/ppx_deriving_show.ml
@@ -5,13 +5,28 @@ open Parsetree
 open Ast_helper
 open Ast_convenience
 
+module StringSet = Ppx_deriving.StringSet
+
 let deriver = "show"
 let raise_errorf = Ppx_deriving.raise_errorf
 
+type show_options =
+  {
+    allow_std_type_masking: bool;
+  }
+
+let default_show_options =
+  {
+    allow_std_type_masking = false;
+  }
+
 let parse_options options =
-  options |> List.iter (fun (name, expr) ->
+  let option_parser acc (name, expr) =
     match name with
-    | _ -> raise_errorf ~loc:expr.pexp_loc "%s does not support option %s" deriver name)
+    | "allow_std_type_masking" -> { allow_std_type_masking = true }
+    | _ ->
+      raise_errorf ~loc:expr.pexp_loc "%s does not support option %s" deriver name in
+  List.fold_left option_parser default_show_options options
 
 let attr_printer attrs =
   Ppx_deriving.(attrs |> attr ~deriver "printer" |> Arg.(get_attr ~deriver expr))
@@ -25,7 +40,7 @@ let attr_opaque attrs =
 let argn = Printf.sprintf "a%d"
 
 let pp_type_of_decl ~options ~path type_decl =
-  parse_options options;
+  ignore (parse_options options);
   let typ = Ppx_deriving.core_type_of_type_decl type_decl in
   Ppx_deriving.poly_arrow_of_type_decl
     (fun var -> [%type: Format.formatter -> [%t var] -> unit])
@@ -33,21 +48,30 @@ let pp_type_of_decl ~options ~path type_decl =
     [%type: Format.formatter -> [%t typ] -> unit]
 
 let show_type_of_decl ~options ~path type_decl =
-  parse_options options;
+  ignore (parse_options options);
   let typ = Ppx_deriving.core_type_of_type_decl type_decl in
   Ppx_deriving.poly_arrow_of_type_decl
     (fun var -> [%type: Format.formatter -> [%t var] -> unit])
     type_decl
-    [%type: [%t typ] -> string]
+    [%type: [%t typ] -> String.t] (* using String.t in case of std type hiding. *)
 
 let sig_of_type ~options ~path type_decl =
-  parse_options options;
+  ignore (parse_options options);
   [Sig.value (Val.mk (mknoloc (Ppx_deriving.mangle_type_decl (`Prefix "pp") type_decl))
               (pp_type_of_decl ~options ~path type_decl));
    Sig.value (Val.mk (mknoloc (Ppx_deriving.mangle_type_decl (`Prefix "show") type_decl))
               (show_type_of_decl ~options ~path type_decl))]
 
-let rec expr_of_typ typ =
+let rec expr_of_typ group_def typ =
+  let generate_printer_call lid args =
+    let args_pp = List.map (fun typ -> [%expr fun fmt -> [%e expr_of_typ group_def typ]]) args in
+    match attr_polyprinter typ.ptyp_attributes with
+    | Some printer ->
+      app [%expr (let fprintf = Format.fprintf in [%e printer]) [@ocaml.warning "-26"]]
+          (args_pp @ [[%expr fmt]])
+    | None ->
+      app (Exp.ident (mknoloc (Ppx_deriving.mangle_lid (`Prefix "pp") lid)))
+          (args_pp @ [[%expr fmt]]) in
   match attr_printer typ.ptyp_attributes with
   | Some printer ->
     [%expr (let fprintf = Format.fprintf in [%e printer]) fmt [@ocaml.warning "-26"]]
@@ -61,10 +85,12 @@ let rec expr_of_typ typ =
         Format.fprintf fmt [%e str start];
         ignore ([%e fold] (fun sep x ->
           if sep then Format.fprintf fmt ";@ ";
-          [%e expr_of_typ typ] x; true) false x);
+          [%e expr_of_typ group_def typ] x; true) false x);
         Format.fprintf fmt [%e str finish];]
     in
     match typ with
+    | { ptyp_desc = Ptyp_constr ({ txt = (Lident id as lid) }, args) } when
+            StringSet.mem id group_def -> generate_printer_call lid args
     | [%type: _]      -> [%expr fun _ -> Format.pp_print_string fmt "_"]
     | [%type: unit]   -> [%expr fun () -> Format.pp_print_string fmt "()"]
     | [%type: int]    -> format "%d"
@@ -74,12 +100,12 @@ let rec expr_of_typ typ =
     | [%type: float]  -> format "%F"
     | [%type: bool]   -> format "%B"
     | [%type: char]   -> format "%C"
-    | [%type: string] -> format "%S"
+    | [%type: string] | [%type: String.t] -> format "%S"
     | [%type: bytes]  -> [%expr fun x -> Format.fprintf fmt "%S" (Bytes.to_string x)]
     | [%type: [%t? typ] ref]   ->
       [%expr fun x ->
         Format.pp_print_string fmt "ref (";
-        [%e expr_of_typ typ] !x;
+        [%e expr_of_typ group_def typ] !x;
         Format.pp_print_string fmt ")"]
     | [%type: [%t? typ] list]  -> seq "[@[<hov>"   "@]]" [%expr List.fold_left]  typ
     | [%type: [%t? typ] array] -> seq "[|@[<hov>" "@]|]" [%expr Array.fold_left] typ
@@ -89,22 +115,14 @@ let rec expr_of_typ typ =
         | None -> Format.pp_print_string fmt "None"
         | Some x ->
           Format.pp_print_string fmt "(Some ";
-          [%e expr_of_typ typ] x;
+          [%e expr_of_typ group_def typ] x;
           Format.pp_print_string fmt ")"]
     | { ptyp_desc = Ptyp_arrow _ } ->
       [%expr fun _ -> Format.pp_print_string fmt "<fun>"]
     | { ptyp_desc = Ptyp_constr ({ txt = lid }, args) } ->
-      let args_pp = List.map (fun typ -> [%expr fun fmt -> [%e expr_of_typ typ]]) args in
-      begin match attr_polyprinter typ.ptyp_attributes with
-      | Some printer ->
-        app [%expr (let fprintf = Format.fprintf in [%e printer]) [@ocaml.warning "-26"]]
-            (args_pp @ [[%expr fmt]])
-      | None ->
-        app (Exp.ident (mknoloc (Ppx_deriving.mangle_lid (`Prefix "pp") lid)))
-            (args_pp @ [[%expr fmt]])
-      end
+        generate_printer_call lid args
     | { ptyp_desc = Ptyp_tuple typs } ->
-      let args = List.mapi (fun i typ -> app (expr_of_typ typ) [evar (argn i)]) typs in
+      let args = List.mapi (fun i typ -> app (expr_of_typ group_def typ) [evar (argn i)]) typs in
       [%expr
         fun [%p ptuple (List.mapi (fun i _ -> pvar (argn i)) typs)] ->
         Format.fprintf fmt "(@[<hov>";
@@ -121,34 +139,34 @@ let rec expr_of_typ typ =
           | Rtag (label, _, false, [typ]) ->
             Exp.case (Pat.variant label (Some [%pat? x]))
                      [%expr Format.fprintf fmt [%e str ("`" ^ label ^ " (@[<hov>")];
-                            [%e expr_of_typ typ] x;
+                            [%e expr_of_typ group_def typ] x;
                             Format.fprintf fmt "@])"]
           | Rinherit ({ ptyp_desc = Ptyp_constr (tname, _) } as typ) ->
             Exp.case [%pat? [%p Pat.type_ tname] as x]
-                     [%expr [%e expr_of_typ typ] x]
+                     [%expr [%e expr_of_typ group_def typ] x]
           | _ ->
             raise_errorf ~loc:ptyp_loc "%s cannot be derived for %s"
                          deriver (Ppx_deriving.string_of_core_type typ))
       in
       Exp.function_ cases
     | { ptyp_desc = Ptyp_var name } -> [%expr [%e evar ("poly_"^name)] fmt]
-    | { ptyp_desc = Ptyp_alias (typ, _) } -> expr_of_typ typ
+    | { ptyp_desc = Ptyp_alias (typ, _) } -> expr_of_typ group_def typ
     | { ptyp_loc } ->
       raise_errorf ~loc:ptyp_loc "%s cannot be derived for %s"
                    deriver (Ppx_deriving.string_of_core_type typ)
 
-let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
-  parse_options options;
+let str_of_type ~options ~path group_def ({ ptype_loc = loc } as type_decl) =
+  ignore (parse_options options);
   let path = Ppx_deriving.path_of_type_decl ~path type_decl in
   let prettyprinter =
     match type_decl.ptype_kind, type_decl.ptype_manifest with
     | Ptype_abstract, Some manifest ->
-      [%expr fun fmt -> [%e expr_of_typ manifest]]
+      [%expr fun fmt -> [%e expr_of_typ group_def manifest]]
     | Ptype_variant constrs, _ ->
       let cases =
         constrs |> List.map (fun { pcd_name = { txt = name' }; pcd_args } ->
           let constr_name = Ppx_deriving.expand_path ~path name' in
-          let args = List.mapi (fun i typ -> app (expr_of_typ typ) [evar (argn i)]) pcd_args in
+          let args = List.mapi (fun i typ -> app (expr_of_typ group_def typ) [evar (argn i)]) pcd_args in
           let result =
             match args with
             | []   -> [%expr Format.pp_print_string fmt [%e str constr_name]]
@@ -171,7 +189,7 @@ let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
         labels |> List.mapi (fun i { pld_name = { txt = name }; pld_type } ->
           let field_name = if i = 0 then Ppx_deriving.expand_path ~path name else name in
           [%expr Format.pp_print_string fmt [%e str (field_name ^ " = ")];
-            [%e expr_of_typ pld_type] [%e Exp.field (evar "x") (mknoloc (Lident name))]])
+            [%e expr_of_typ group_def pld_type] [%e Exp.field (evar "x") (mknoloc (Lident name))]])
       in
       [%expr fun fmt x ->
         Format.fprintf fmt "{ @[<hov>";
@@ -199,12 +217,22 @@ let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
   [Vb.mk (Pat.constraint_ pp_var pp_type) (polymorphize prettyprinter);
    Vb.mk (Pat.constraint_ show_var show_type) (polymorphize stringprinter);]
 
+let type_decl_str ~options ~path type_decls =
+  let opts = parse_options options in
+  let typename_set =
+    Ppx_deriving.extract_typename_of_type_group 
+      deriver
+      ~allow_shadowing:opts.allow_std_type_masking
+      type_decls in
+  let code =
+    List.map (str_of_type ~options ~path typename_set) type_decls in
+  [Str.value Recursive (List.concat code)]
+
 let () =
   Ppx_deriving.(register (create deriver
     ~core_type: (fun typ ->
-      [%expr fun x -> Format.asprintf "%a" (fun fmt -> [%e expr_of_typ typ]) x])
-    ~type_decl_str: (fun ~options ~path type_decls ->
-      [Str.value Recursive (List.concat (List.map (str_of_type ~options ~path) type_decls))])
+      [%expr fun x -> Format.asprintf "%a" (fun fmt -> [%e expr_of_typ StringSet.empty typ]) x])
+    ~type_decl_str: type_decl_str
     ~type_decl_sig: (fun ~options ~path type_decls ->
       List.concat (List.map (sig_of_type ~options ~path) type_decls))
     ()

--- a/src_test/test_deriving_eq.ml
+++ b/src_test/test_deriving_eq.ml
@@ -90,7 +90,7 @@ and bool_ =
   | Bfoo of int * ((int -> int) [@equal fun _ _ -> true])
 and string =
   | Sfoo of String.t * ((int -> int) [@equal fun _ _ -> true])
-  [@@deriving eq{ allow_std_type_masking }]
+  [@@deriving eq{ allow_std_type_shadowing }]
 
 let test_shadowed_std_type ctxt =
   let e1 = ESBool (Bfoo (1, (+) 1)) in

--- a/src_test/test_deriving_eq.ml
+++ b/src_test/test_deriving_eq.ml
@@ -83,6 +83,23 @@ let test_mut_rec ctxt =
   assert_equal ~printer false (equal_e e1 e2);
   assert_equal ~printer false (equal_e e2 e1)
 
+type es =
+  | ESBool of bool
+  | ESString of string
+and bool =
+  | Bfoo of int * ((int -> int) [@equal fun _ _ -> true])
+and string =
+  | Sfoo of String.t * ((int -> int) [@equal fun _ _ -> true])
+  [@@deriving eq{ allow_std_type_masking }]
+
+let test_shadowed_std_type ctxt =
+  let e1 = ESBool (Bfoo (1, (+) 1)) in
+  let e2 = ESString (Sfoo ("lalala", (+) 3)) in
+  assert_equal ~printer false (compare_es e1 e2);
+  assert_equal ~printer false (compare_es e2 e1);
+  assert_equal ~printer true (compare_es e1 e1);
+  assert_equal ~printer true (compare_es e2 e2)
+
 
 let suite = "Test deriving(eq)" >::: [
     "test_simple"       >:: test_simple;

--- a/src_test/test_deriving_eq.ml
+++ b/src_test/test_deriving_eq.ml
@@ -84,9 +84,9 @@ let test_mut_rec ctxt =
   assert_equal ~printer false (equal_e e2 e1)
 
 type es =
-  | ESBool of bool
+  | ESBool of bool_
   | ESString of string
-and bool =
+and bool_ =
   | Bfoo of int * ((int -> int) [@equal fun _ _ -> true])
 and string =
   | Sfoo of String.t * ((int -> int) [@equal fun _ _ -> true])
@@ -95,10 +95,10 @@ and string =
 let test_shadowed_std_type ctxt =
   let e1 = ESBool (Bfoo (1, (+) 1)) in
   let e2 = ESString (Sfoo ("lalala", (+) 3)) in
-  assert_equal ~printer false (compare_es e1 e2);
-  assert_equal ~printer false (compare_es e2 e1);
-  assert_equal ~printer true (compare_es e1 e1);
-  assert_equal ~printer true (compare_es e2 e2)
+  assert_equal ~printer false (equal_es e1 e2);
+  assert_equal ~printer false (equal_es e2 e1);
+  assert_equal ~printer true (equal_es e1 e1);
+  assert_equal ~printer true (equal_es e2 e2)
 
 
 let suite = "Test deriving(eq)" >::: [

--- a/src_test/test_deriving_ord.ml
+++ b/src_test/test_deriving_ord.ml
@@ -105,7 +105,7 @@ and bool =
   | Bfoo of int * ((int -> int) [@compare fun _ _ -> 0])
 and string =
   | Sfoo of String.t * ((int -> int) [@compare fun _ _ -> 0])
-  [@@deriving ord{ allow_std_type_masking }]
+  [@@deriving ord{ allow_std_type_shadowing }]
 
 let test_shadowed_std_type ctxt =
   let e1 = ESBool (Bfoo (1, (+) 1)) in

--- a/src_test/test_deriving_ord.ml
+++ b/src_test/test_deriving_ord.ml
@@ -98,6 +98,22 @@ let test_mutualy_recursive ctxt =
   assert_equal ~printer (-1) (compare_e ce1 ce2);
   assert_equal ~printer (1) (compare_e ce2 ce1)
 
+type es =
+  | ESBool of bool
+  | ESString of string
+and bool =
+  | Bfoo of int * ((int -> int) [@compare fun _ _ -> 0])
+and string =
+  | Sfoo of String.t * ((int -> int) [@compare fun _ _ -> 0])
+  [@@deriving ord{ allow_std_type_masking }]
+
+let test_shadowed_std_type ctxt =
+  let e1 = ESBool (Bfoo (1, (+) 1)) in
+  let e2 = ESString (Sfoo ("lalala", (+) 3)) in
+  assert_equal ~printer (-1) (compare_es e1 e2);
+  assert_equal ~printer (1) (compare_es e2 e1);
+  assert_equal ~printer 0 (compare_es e1 e1);
+  assert_equal ~printer 0 (compare_es e2 e2)
 
 let suite = "Test deriving(ord)" >::: [
     "test_simple"       >:: test_simple;
@@ -107,5 +123,6 @@ let suite = "Test deriving(ord)" >::: [
     "test_placeholder"  >:: test_placeholder;
     "test_mrec"         >:: test_mrec;
     "test_mutualy_recursive" >:: test_mutualy_recursive;
+    "test_shadowed_std_type" >:: test_shadowed_std_type;
   ]
 

--- a/src_test/test_deriving_show.ml
+++ b/src_test/test_deriving_show.ml
@@ -134,6 +134,25 @@ let test_mut_rec ctxt =
   let e1 =  B { x = 12; r = F 16 } in
   assert_equal ~printer "(Test_deriving_show.B\n   { Test_deriving_show.x = 12; r = (Test_deriving_show.F 16) })" (show_foo e1)
 
+type es =
+  | ESBool of bool
+  | ESString of string
+and bool =
+  | Bfoo of int * (int -> int)
+and string =
+  | Sfoo of String.t * (int -> int)
+  [@@deriving show{ allow_std_type_masking }]
+
+let test_shadowed_std_type ctxt =
+  let e1 = ESBool (Bfoo (1, (+) 1)) in
+  let e2 = ESString (Sfoo ("lalala", (+) 3)) in
+  assert_equal ~printer
+    "(Test_deriving_show.ESBool Test_deriving_show.Bfoo (1, <fun>))"
+    (show_es e1);
+  assert_equal ~printer
+    "(Test_deriving_show.ESString Test_deriving_show.Sfoo (\"lalala\", <fun>))"
+    (show_es e2)
+
 let suite = "Test deriving(show)" >::: [
     "test_alias"        >:: test_alias;
     "test_variant"      >:: test_variant;
@@ -149,4 +168,5 @@ let suite = "Test deriving(show)" >::: [
     "test_polypr"       >:: test_polypr;
     "test_placeholder"  >:: test_placeholder;
     "test_mut_rec"      >:: test_mut_rec;
+    "test_shadowed_std_type" >:: test_shadowed_std_type;
   ]

--- a/src_test/test_deriving_show.ml
+++ b/src_test/test_deriving_show.ml
@@ -141,7 +141,7 @@ and bool =
   | Bfoo of int * (int -> int)
 and string =
   | Sfoo of String.t * (int -> int)
-  [@@deriving show{ allow_std_type_masking }]
+  [@@deriving show{ allow_std_type_shadowing }]
 
 let test_shadowed_std_type ctxt =
   let e1 = ESBool (Bfoo (1, (+) 1)) in


### PR DESCRIPTION
Shadowing standard type, while definitely bad style, will result in invalid generated code using ppx_deriving (and I know a code base with those...):

~~~~{ocaml}
type es =
  | ESBool of bool
  | ESString of string
and bool =
  | Bfoo of int * ((int -> int) [@compare fun _ _ -> 0])
and string =
  | Sfoo of String.t * ((int -> int) [@compare fun _ _ -> 0])
  [@@deriving ord{ allow_std_type_masking }]
~~~~

will call `Pervasives.compare` for `ESBool` and `ESString`, yielding to a crash at runtime. The first solution implemented in this patch is to reject derivation of shadowed types. If you known what you're doing, you can use the `allow_std_type_masking` to force derivation (if possible), and try to call the good functions while generating code for the mutually recursive types (like the one added in the examples).

While testing, I found that some warning were generated with types of only one constructor, due to the unreached wildcard pattern, there is a fix for this.

All of this implemented for ord/eq/show