### PR TITLE
Remove warning 4

### DIFF
--- a/src/ppx_deriving.ml
+++ b/src/ppx_deriving.ml
@@ -161,6 +161,11 @@ let attr ~deriver name attrs =
   try Some (List.find (fun ({ txt }, _) -> txt = name) attrs)
   with Not_found -> None
 
+let attr_warning expr =
+  let loc = !default_loc in
+  let structure = {pstr_desc = Pstr_eval (expr, []); pstr_loc = loc} in
+  {txt = "ocaml.warning"; loc}, PStr [structure]
+
 let fold_left_type_params fn accum params =
   List.fold_left (fun accum (param, _) ->
       match param with

--- a/src/ppx_deriving.mli
+++ b/src/ppx_deriving.mli
@@ -159,6 +159,9 @@ val mangle_lid : ?fixpoint:string ->
     or [\[\@attr\]] otherwise. *)
 val attr : deriver:string -> string -> attributes -> attribute option
 
+(** [attr_warning expr] builds the attribute [@ocaml.warning expr] *)
+val attr_warning: expression -> attribute
+
 (** [free_vars_in_core_type typ] returns unique free variables in [typ] in
     lexical order. *)
 val free_vars_in_core_type : core_type -> string list
@@ -239,7 +242,7 @@ val seq_reduce : ?sep:expression -> expression -> expression -> expression
 (** [binop_reduce] ≡ [fun x a b -> [%expr [%e x] [%e a] [%e b]]]. *)
 val binop_reduce : expression -> expression -> expression -> expression
 
-(** [strong_type_of_type ty] transform a type ty to 
+(** [strong_type_of_type ty] transform a type ty to
     [freevars . ty], giving a strong polymorphic type *)
 val strong_type_of_type: core_type -> core_type
 

--- a/src/ppx_deriving.mli
+++ b/src/ppx_deriving.mli
@@ -159,7 +159,7 @@ val mangle_lid : ?fixpoint:string ->
     or [\[\@attr\]] otherwise. *)
 val attr : deriver:string -> string -> attributes -> attribute option
 
-(** [attr_warning expr] builds the attribute [@ocaml.warning expr] *)
+(** [attr_warning expr] builds the attribute [\@ocaml.warning expr] *)
 val attr_warning: expression -> attribute
 
 (** [free_vars_in_core_type typ] returns unique free variables in [typ] in

--- a/src_plugins/ppx_deriving_ord.ml
+++ b/src_plugins/ppx_deriving_ord.ml
@@ -46,6 +46,15 @@ let wildcard_case int_cases =
     let to_int = [%e Exp.function_ int_cases] in
     Pervasives.compare (to_int lhs) (to_int rhs)]
 
+let attr_warning expr =
+  let loc = !default_loc in
+  let structure = {pstr_desc = Pstr_eval (expr, []); pstr_loc = loc} in
+  {txt = "ocaml.warning"; loc}, PStr [structure]
+
+(* deactivate warning 4 in code that uses [wildcard_case] *)
+let warning_minus_4 =
+  attr_warning [%expr "-4"]
+
 let pattn side typs =
   List.mapi (fun i _ -> pvar (argn side i)) typs
 
@@ -131,7 +140,7 @@ and expr_of_typ group_def typ =
             | _ -> assert false)
         in
         [%expr fun lhs rhs ->
-          [%e Exp.match_ [%expr lhs, rhs] (cases @ [wildcard_case int_cases])]]
+          [%e Exp.match_ ~attrs:[warning_minus_4] [%expr lhs, rhs] (cases @ [wildcard_case int_cases])]]
       | { ptyp_desc = Ptyp_var name } -> evar ("poly_"^name)
       | { ptyp_desc = Ptyp_alias (typ, _) } -> aux typ
       | { ptyp_loc } ->
@@ -171,7 +180,7 @@ let str_of_type ~options ~path group_def ({ ptype_loc = loc } as type_decl) =
         | [] | [_] -> []
         | _ :: _ :: _ -> [wildcard_case int_cases] in
       [%expr fun lhs rhs ->
-        [%e Exp.match_ [%expr lhs, rhs] (cases @ wildcard)]]
+        [%e Exp.match_ ~attrs:[warning_minus_4] [%expr lhs, rhs] (cases @ wildcard)]]
     | Ptype_record labels, _ ->
       let exprs =
         labels |> List.map (fun { pld_name = { txt = name }; pld_type } ->
@@ -196,7 +205,7 @@ let str_of_type ~options ~path group_def ({ ptype_loc = loc } as type_decl) =
 let type_decl_str ~options ~path type_decls =
   let opts = parse_options options in
   let typename_set =
-    Ppx_deriving.extract_typename_of_type_group 
+    Ppx_deriving.extract_typename_of_type_group
       deriver
       ~allow_shadowing:opts.allow_std_type_shadowing
       type_decls in
@@ -217,4 +226,3 @@ let () =
       List.concat (List.map (sig_of_type ~options ~path) type_decls))
     ()
   ))
-

--- a/src_plugins/ppx_deriving_ord.ml
+++ b/src_plugins/ppx_deriving_ord.ml
@@ -46,14 +46,9 @@ let wildcard_case int_cases =
     let to_int = [%e Exp.function_ int_cases] in
     Pervasives.compare (to_int lhs) (to_int rhs)]
 
-let attr_warning expr =
-  let loc = !default_loc in
-  let structure = {pstr_desc = Pstr_eval (expr, []); pstr_loc = loc} in
-  {txt = "ocaml.warning"; loc}, PStr [structure]
-
 (* deactivate warning 4 in code that uses [wildcard_case] *)
 let warning_minus_4 =
-  attr_warning [%expr "-4"]
+  Ppx_deriving.attr_warning [%expr "-4"]
 
 let pattn side typs =
   List.mapi (fun i _ -> pvar (argn side i)) typs

--- a/src_test/test_deriving_ord.ml
+++ b/src_test/test_deriving_ord.ml
@@ -115,6 +115,20 @@ let test_shadowed_std_type ctxt =
   assert_equal ~printer 0 (compare_es e1 e1);
   assert_equal ~printer 0 (compare_es e2 e2)
 
+module Warnings = struct
+  module W4 = struct
+    (* Module does not compile if warning 4 is triggered by the ord
+       deriver. *)
+
+    [@@@ocaml.warning "@4"]
+
+    type t =
+      | A of int
+      | B
+          [@@deriving ord]
+  end
+end
+
 let suite = "Test deriving(ord)" >::: [
     "test_simple"       >:: test_simple;
     "test_variant"      >:: test_variant;
@@ -125,4 +139,3 @@ let suite = "Test deriving(ord)" >::: [
     "test_mutualy_recursive" >:: test_mutualy_recursive;
     "test_shadowed_std_type" >:: test_shadowed_std_type;
   ]
-


### PR DESCRIPTION
Warning 4 is triggered by the code produced with the ppx_deriving_ord plugin (which uses wildcards). The warning does not make much sense in that case (because the code is auto generated), hence it can be safely deactivated in the `match` construct built by `ord`.