### PR TITLE
merge attributes of record fields and types (for OCaml 4.02.2)

### DIFF
--- a/src_plugins/ppx_deriving_eq.ml
+++ b/src_plugins/ppx_deriving_eq.ml
@@ -139,7 +139,10 @@ let str_of_type ~options ~path group_def ({ ptype_loc = loc } as type_decl) =
       [%expr fun lhs rhs -> [%e Exp.match_ [%expr lhs, rhs] cases]]
     | Ptype_record labels, _ ->
       let exprs =
-        labels |> List.map (fun { pld_name = { txt = name }; pld_type } ->
+        labels |> List.map (fun { pld_name = { txt = name }; pld_type; pld_attributes } ->
+          (* combine attributes of type and label *)
+          let attrs =  pld_type.ptyp_attributes @ pld_attributes in
+          let pld_type = {pld_type with ptyp_attributes=attrs} in
           let field obj = Exp.field obj (mknoloc (Lident name)) in
           app (expr_of_typ group_def pld_type) [field (evar "lhs"); field (evar "rhs")])
       in

--- a/src_plugins/ppx_deriving_ord.ml
+++ b/src_plugins/ppx_deriving_ord.ml
@@ -178,7 +178,9 @@ let str_of_type ~options ~path group_def ({ ptype_loc = loc } as type_decl) =
         [%e Exp.match_ ~attrs:[warning_minus_4] [%expr lhs, rhs] (cases @ wildcard)]]
     | Ptype_record labels, _ ->
       let exprs =
-        labels |> List.map (fun { pld_name = { txt = name }; pld_type } ->
+        labels |> List.map (fun { pld_name = { txt = name }; pld_type; pld_attributes } ->
+          let attrs = pld_attributes @ pld_type.ptyp_attributes in
+          let pld_type = {pld_type with ptyp_attributes=attrs} in
           let field obj = Exp.field obj (mknoloc (Lident name)) in
           app (expr_of_typ group_def pld_type) [field (evar "lhs"); field (evar "rhs")])
       in

--- a/src_plugins/ppx_deriving_show.ml
+++ b/src_plugins/ppx_deriving_show.ml
@@ -186,8 +186,9 @@ let str_of_type ~options ~path group_def ({ ptype_loc = loc } as type_decl) =
       [%expr fun fmt -> [%e Exp.function_ cases]]
     | Ptype_record labels, _ ->
       let fields =
-        labels |> List.mapi (fun i { pld_name = { txt = name }; pld_type } ->
+        labels |> List.mapi (fun i { pld_name = { txt = name }; pld_type; pld_attributes } ->
           let field_name = if i = 0 then Ppx_deriving.expand_path ~path name else name in
+          let pld_type = {pld_type with ptyp_attributes=pld_attributes@pld_type.ptyp_attributes} in
           [%expr Format.pp_print_string fmt [%e str (field_name ^ " = ")];
             [%e expr_of_typ group_def pld_type] [%e Exp.field (evar "x") (mknoloc (Lident name))]])
       in


### PR DESCRIPTION
First attempt at fixing #39. Strategy: for every record field `{label : ty}`, put attributes of `label` into `ty`.