### PR TITLE
Fix rm -rf in test, examples targets on OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,12 @@ build:
 	ocaml pkg/build.ml native=true native-dynlink=true
 
 test: build
-	rm _build/src_test/ -rf
+	rm -rf _build/src_test/
 	ocamlbuild -j 0 -use-ocamlfind -classic-display \
 		src_test/test_ppx_deriving.byte --
 
 examples: build
-	rm _build/src_examples/ -rf
+	rm -rf _build/src_examples/
 	ocamlbuild -j 0 -use-ocamlfind -classic-display \
 	    src_examples/print_test.byte
 


### PR DESCRIPTION
Flags to rm must come first on OSX. For example:

```
rm _build -rf
rm: _build: is a directory
rm: -rf: No such file or directory
```