### PR TITLE
Handle polymorphic variants in free var calculation

### DIFF
--- a/src/ppx_deriving.ml
+++ b/src/ppx_deriving.ml
@@ -206,7 +206,12 @@ let free_vars_in_core_type typ =
       List.map free_in xs |> List.concat
     | { ptyp_desc = Ptyp_alias (x, name) } -> [name] @ free_in x
     | { ptyp_desc = Ptyp_poly (bound, x) } ->
-      List.filter (fun y -> not (List.mem y bound)) (free_in x)
+       List.filter (fun y -> not (List.mem y bound)) (free_in x)
+    | { ptyp_desc = Ptyp_variant (rows, _, _) } ->
+       List.map (
+           function Rtag (_,_,_,ts) -> List.map free_in ts
+                  | Rinherit t -> [free_in t]
+         ) rows |> List.concat |> List.concat
     | _ -> assert false
   in
   let rec uniq acc lst =


### PR DESCRIPTION
This is a necessary addition to apply something like #23 to
ppx_deriving_yojson.

Signed-off-by: Christoph Höger <christoph.hoeger@tu-berlin.de>