### PR TITLE
Eta expand equality functions

### DIFF
--- a/src_plugins/ppx_deriving_eq.ml
+++ b/src_plugins/ppx_deriving_eq.ml
@@ -84,7 +84,9 @@ and expr_of_typ quoter typ =
         [%expr fun (lazy x) (lazy y) -> [%e expr_of_typ typ] x y]
       | _, { ptyp_desc = Ptyp_constr ({ txt = lid }, args) } ->
         let equal_fn = Exp.ident (mknoloc (Ppx_deriving.mangle_lid (`Prefix "equal") lid)) in
-        app equal_fn (List.map expr_of_typ args)
+        let fwd = app equal_fn (List.map expr_of_typ args) in
+        (* eta-expansion is necessary for recursive groups *)
+        [%expr fun x -> [%e fwd] x]
       | _ -> assert false
       end
     | { ptyp_desc = Ptyp_tuple typs } ->

--- a/src_test/test_deriving_eq.ml
+++ b/src_test/test_deriving_eq.ml
@@ -101,6 +101,13 @@ let test_std_shadowing ctxt =
   assert_equal ~printer true (equal_es e1 e1);
   assert_equal ~printer true (equal_es e2 e2)
 
+type poly_app = float poly_abs
+
+and 'a poly_abs = 'a [@@deriving eq]
+
+let test_poly_app ctxt =
+  assert_equal ~printer true (equal_poly_app 1.0 1.0) ;
+  assert_equal ~printer false (equal_poly_app 1.0 2.0)
 
 let suite = "Test deriving(eq)" >::: [
     "test_simple"        >:: test_simple;
@@ -108,6 +115,7 @@ let suite = "Test deriving(eq)" >::: [
     "test_placeholder"   >:: test_placeholder;
     "test_mrec"          >:: test_mrec;
     "test_mut_rec"       >:: test_mut_rec;
-    "test_std_shadowing" >:: test_std_shadowing
+    "test_std_shadowing" >:: test_std_shadowing;
+    "test_poly_app"      >:: test_poly_app
   ]
 


### PR DESCRIPTION
This is necessary in case of recursive groups, due to
the let-rec restriction to syntactic functions.

Such a change is possibly necessary for other plugins
as well.

Signed-off-by: Christoph Höger <christoph.hoeger@tu-berlin.de>