### PR TITLE
Link ppx_deriving_main with linkall

### DIFF
--- a/_tags
+++ b/_tags
@@ -3,6 +3,7 @@ true: warn(@5@8@10@11@12@14@23@24@26@29@40), bin_annot, safe_string, debug
 
 "src": include
 <src/*.{ml,mli,byte,native}>: package(dynlink), package(compiler-libs.common), package(ppx_tools.metaquot)
+<src/ppx_deriving_main.{byte,native}>: linkall
 <src_plugins/*.{ml,mli}>: package(compiler-libs.common), package(ppx_tools.metaquot)
 
 <src_test/*.{ml,byte,native}>: debug, package(oUnit ppx_tools compiler-libs.common), use_deriving


### PR DESCRIPTION
The ppx\_deriving binary should be linked with `-linkall` so that plugins are free to use modules of the stdlib that are not referenced by ppx_deriving itself.