### PR TITLE
Do not create empty let-binding

### DIFF
--- a/src/ppx_deriving.ml
+++ b/src/ppx_deriving.ml
@@ -125,8 +125,10 @@ let quote ~quoter expr =
   [%expr [%e evar name] ()]
 
 let sanitize ?(quoter=create_quoter ()) expr =
-  Exp.let_ Nonrecursive quoter.bindings [%expr
-    (let open! Ppx_deriving_runtime in [%e expr]) [@ocaml.warning "-A"]]
+  let bdy = [%expr (let open! Ppx_deriving_runtime in [%e expr]) [@ocaml.warning "-A"]] in
+  match quoter.bindings with
+    [] -> bdy
+  | bindings -> Exp.let_ Nonrecursive bindings bdy
 
 let with_quoter fn a =
   let quoter = create_quoter () in


### PR DESCRIPTION
This may yield an error in the concrete syntax, when the
modified AST is later dumped (e.g. for debugging purposes).
It might also fail later on (in case the compiler acts less
generous in that area).

Signed-off-by: Christoph Höger <christoph.hoeger@tu-berlin.de>