### PR TITLE
Fix META with ocp-build

### DIFF
--- a/pkg/META.in
+++ b/pkg/META.in
@@ -25,9 +25,7 @@ package "main" (
 package "std" (
   version = "%{version}%"
   description = "Meta-package for all built-in derivers"
-  requires  = "ppx_deriving.show ppx_deriving.eq ppx_deriving.ord"
-  requires += "ppx_deriving.enum ppx_deriving.iter ppx_deriving.map"
-  requires += "ppx_deriving.fold ppx_deriving.create"
+  requires  = "ppx_deriving.show ppx_deriving.eq ppx_deriving.ord ppx_deriving.enum ppx_deriving.iter ppx_deriving.map ppx_deriving.fold ppx_deriving.create"
 )
 
 package "show" (


### PR DESCRIPTION
`ocp-build` does not handle the `+=` in META file.