### PR TITLE
Honor the [@printer] annotation for variant types.

### DIFF
--- a/src_plugins/ppx_deriving_show.ml
+++ b/src_plugins/ppx_deriving_show.ml
@@ -170,26 +170,37 @@ let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
       [%expr fun fmt -> [%e expr_of_typ quoter manifest]]
     | Ptype_variant constrs, _ ->
       let cases =
-        constrs |> List.map (fun { pcd_name = { txt = name' }; pcd_args } ->
-          let constr_name = Ppx_deriving.expand_path ~path name' in
-          let args =
-            List.mapi (fun i typ -> app (expr_of_typ quoter typ) [evar (argn i)]) pcd_args
-          in
-          let result =
-            match args with
-            | []   -> [%expr Format.pp_print_string fmt [%e str constr_name]]
-            | [arg] ->
-              [%expr
-                Format.fprintf fmt [%e str ("(@[<hov2>" ^  constr_name ^ "@ ")];
-                [%e arg];
-                Format.fprintf fmt "@])"]
-            | args ->
-              [%expr Format.fprintf fmt [%e str ("@[<hov2>" ^  constr_name ^ " (@,")];
-              [%e args |> Ppx_deriving.(fold_exprs
-                    (seq_reduce ~sep:[%expr Format.fprintf fmt ",@ "]))];
-              Format.fprintf fmt "@])"]
-          in
-          Exp.case (pconstr name' (List.mapi (fun i _ -> pvar (argn i)) pcd_args)) result)
+        constrs |> List.map (fun { pcd_name = { txt = name' }; pcd_args; pcd_attributes } ->
+          match attr_printer pcd_attributes with
+            | Some printer ->
+                let printer =
+                  [%expr (let fprintf = Format.fprintf in [%e printer]) [@ocaml.warning "-26"]]
+                in let expr = match pcd_args with
+                  | [] ->
+                      Exp.case (pconstr name' []) [%expr [%e Ppx_deriving.quote quoter printer] fmt ()]
+                  | _ ->
+                      Exp.case (pconstr name' [pvar "a"]) [%expr [%e Ppx_deriving.quote quoter printer] fmt a]
+                in expr
+            | None -> 
+                let constr_name = Ppx_deriving.expand_path ~path name' in
+                let args =
+                  List.mapi (fun i typ -> app (expr_of_typ quoter typ) [evar (argn i)]) pcd_args
+                in
+                let result =
+                  match args with
+                    | []   -> [%expr Format.pp_print_string fmt [%e str constr_name]]
+                    | [arg] ->
+                        [%expr
+                         Format.fprintf fmt [%e str ("(@[<hov2>" ^  constr_name ^ "@ ")];
+                       [%e arg];
+                       Format.fprintf fmt "@])"]
+                    | args ->
+                        [%expr Format.fprintf fmt [%e str ("@[<hov2>" ^  constr_name ^ " (@,")];
+                      [%e args |> Ppx_deriving.(fold_exprs
+                                                  (seq_reduce ~sep:[%expr Format.fprintf fmt ",@ "]))];
+                      Format.fprintf fmt "@])"]
+                in
+                  Exp.case (pconstr name' (List.mapi (fun i _ -> pvar (argn i)) pcd_args)) result)
       in
       [%expr fun fmt -> [%e Exp.function_ cases]]
     | Ptype_record labels, _ ->

--- a/src_test/test_deriving_show.ml
+++ b/src_test/test_deriving_show.ml
@@ -175,7 +175,7 @@ type variant_printer =
   | First [@printer fun fmt _ -> Format.pp_print_string fmt "first"]
   | Second of int [@printer fun fmt i -> fprintf fmt "second: %d" i]
   | Third
-  [@@deriving show]
+[@@deriving show]
 
 let test_variant_printer ctxt =
   assert_equal ~printer

--- a/src_test/test_deriving_show.ml
+++ b/src_test/test_deriving_show.ml
@@ -171,22 +171,37 @@ end
 type 'a std_clash = 'a List.t option
 [@@deriving show]
 
+type variant_printer =
+  | First [@printer fun fmt _ -> Format.pp_print_string fmt "first"]
+  | Second of int [@printer fun fmt i -> fprintf fmt "second: %d" i]
+  | Third
+  [@@deriving show]
+
+let test_variant_printer ctxt =
+  assert_equal ~printer
+    "first" (show_variant_printer First);
+  assert_equal ~printer
+    "second: 42" (show_variant_printer (Second 42));
+  assert_equal ~printer
+    "Test_deriving_show.Third" (show_variant_printer Third)
+
 let suite = "Test deriving(show)" >::: [
-    "test_alias"         >:: test_alias;
-    "test_variant"       >:: test_variant;
-    "test_variant_nest"  >:: test_variant_nest;
-    "test_tuple"         >:: test_tuple;
-    "test_poly"          >:: test_poly;
-    "test_poly_inherit"  >:: test_poly_inherit;
-    "test_record"        >:: test_record;
-    "test_abstr"         >:: test_abstr;
-    "test_custom"        >:: test_custom;
-    "test_parametric"    >:: test_parametric;
-    "test_alias_path"    >:: test_alias_path;
-    "test_polypr"        >:: test_polypr;
-    "test_placeholder"   >:: test_placeholder;
-    "test_mrec"          >:: test_mrec;
-    "test_std_shadowing" >:: test_std_shadowing;
-    "test_poly_app"      >:: test_poly_app;
+    "test_alias"           >:: test_alias;
+    "test_variant"         >:: test_variant;
+    "test_variant_nest"    >:: test_variant_nest;
+    "test_tuple"           >:: test_tuple;
+    "test_poly"            >:: test_poly;
+    "test_poly_inherit"    >:: test_poly_inherit;
+    "test_record"          >:: test_record;
+    "test_abstr"           >:: test_abstr;
+    "test_custom"          >:: test_custom;
+    "test_parametric"      >:: test_parametric;
+    "test_alias_path"      >:: test_alias_path;
+    "test_polypr"          >:: test_polypr;
+    "test_placeholder"     >:: test_placeholder;
+    "test_mrec"            >:: test_mrec;
+    "test_std_shadowing"   >:: test_std_shadowing;
+    "test_poly_app"        >:: test_poly_app;
+    "test_variant_printer" >:: test_variant_printer;
   ]
 


### PR DESCRIPTION
This patch makes ppx_deriving_show honor [@printer] annotations
on the cases of a variant type, closing
https://github.com/whitequark/ppx_deriving/issues/77.

In particular, consider the following code:

type t =
  | First [@printer fun fmt _ -> Format.fprintf fmt "first case"]
  | Second
      [@@deriving show]

let () =
  Format.printf "%a, %a@." pp First pp Second

It now outputs "first case, Printer_variant.Second".