### PR TITLE
Fix deriving.map on records with non-poly field

### DIFF
--- a/src_plugins/ppx_deriving_map.cppo.ml
+++ b/src_plugins/ppx_deriving_map.cppo.ml
@@ -31,7 +31,7 @@ let  constrrec name fields =  constr name [ record                fields]
 
 let rec expr_of_typ typ =
   match typ with
-  | _ when Ppx_deriving.free_vars_in_core_type typ = [] -> [%expr fun _ -> ()]
+  | _ when Ppx_deriving.free_vars_in_core_type typ = [] -> [%expr fun x -> x]
   | { ptyp_desc = Ptyp_constr _ } ->
     let builtin = not (attr_nobuiltin typ.ptyp_attributes) in
     begin match builtin, typ with

--- a/src_test/test_deriving_map.cppo.ml
+++ b/src_test/test_deriving_map.cppo.ml
@@ -1,5 +1,10 @@
 open OUnit2
 
+let fmt_chr fmt = Format.fprintf fmt "%c"
+let fmt_flt fmt = Format.fprintf fmt "%f"
+let fmt_int fmt = Format.fprintf fmt "%d"
+let fmt_str fmt = Format.fprintf fmt "%s"
+
 type 'a btree = Node of 'a btree * 'a * 'a btree | Leaf
 [@@deriving map, show]
 
@@ -18,6 +23,49 @@ type 'a btreer = Node of { lft: 'a btree; elt: 'a; rgt: 'a btree } | Leaf
 type 'a ty = 'a * int list
 [@@deriving map]
 
+(* records *)
+
+(* no poly field *)
+type record0 = { a0 : int } [@@deriving map,show]
+let test_record0 ctxt = 
+  assert_equal ~printer:show_record0 
+    {a0=0} (map_record0 {a0=0})
+
+(* one poly field *)
+type 'a record1 = { a1 : 'a } [@@deriving map,show]
+let test_record1 ctxt = 
+  assert_equal ~printer:(show_record1 fmt_int)
+    {a1=1} (map_record1 ((+)1) {a1=0})
+
+(* mixture of poly / non-poly fields *)
+type 'a record2 = { a2 : 'a; b2 : int } [@@deriving map,show]
+let test_record2 ctxt = 
+  assert_equal ~printer:(show_record2 fmt_int)
+    {a2=5;b2=7} (map_record2 ((+)1) {a2=4;b2=7})
+
+type ('a,'b) record3 = { a3 : 'a; b3 : bool; c3 : 'b } [@@deriving map,show]
+let test_record3 ctxt = 
+  assert_equal ~printer:(show_record3 fmt_int fmt_str)
+    {a3=5;b3=false;c3="ABC"} (map_record3 ((+)1) String.uppercase {a3=4;b3=false;c3="abc"})
+
+(* change types *)
+let test_record3_poly ctxt =
+  let recd  = {a3='a';b3=true;c3=4} in
+  let mapd = map_record3 Char.code float_of_int recd in
+  let expt  = {a3=97;b3=true;c3=4.} in
+  assert_bool
+    (Printf.sprintf "(map %s = %s) <> %s"
+      (show_record3 fmt_chr fmt_int recd)
+      (show_record3 fmt_int fmt_flt mapd)
+      (show_record3 fmt_int fmt_flt expt))
+    (mapd = expt)
+
 let suite = "Test deriving(map)" >::: [
     "test_btree" >:: test_btree;
+    "test_record0" >:: test_record0;
+    "test_record1" >:: test_record1;
+    "test_record2" >:: test_record2;
+    "test_record3" >:: test_record3;
+    "test_record3_poly" >:: test_record3_poly;
   ]
+


### PR DESCRIPTION
Examples such as

```
type 'a t = { x : 'a; y : string } [@@deriving map]
type 'a t = A of 'a | B of string [@@deriving map]
```

lead to a type error on the non-polymorphic field/constructor arg.  Is this the expected behaviour?  

This patch copies such fields/args instead.