### PR TITLE
Fix type problems in 'map' and 'iter'.

### DIFF
--- a/src/ppx_deriving.cppo.ml
+++ b/src/ppx_deriving.cppo.ml
@@ -313,6 +313,23 @@ let core_type_of_type_decl { ptype_name = { txt = name }; ptype_params } =
 let core_type_of_type_ext { ptyext_path ; ptyext_params } =
   Typ.constr ptyext_path (List.map fst ptyext_params)
 
+let core_type_with_fresh_vars bound type_decl = 
+  let vars,bound = 
+    List.fold_right
+      (fun _ (vars,bound) -> 
+        let v = fresh_var bound in
+        (Typ.var v::vars,v::bound)) 
+      (free_vars_in_core_type (core_type_of_type_decl type_decl))
+      ([],bound) 
+  in
+  let vars = List.rev vars in
+  let core_type = core_type_of_type_decl 
+    { type_decl with 
+        ptype_params = List.map2 (fun var (_,vari) -> var,vari) 
+                                 vars type_decl.ptype_params }
+  in
+  core_type, vars, bound 
+
 let fold_exprs ?unit fn exprs =
   match exprs with
   | [a] -> a

--- a/src/ppx_deriving.mli
+++ b/src/ppx_deriving.mli
@@ -259,6 +259,14 @@ val core_type_of_type_decl : type_declaration -> core_type
 (** Same as {!core_type_of_type_decl} but for type extension. *)
 val core_type_of_type_ext : type_extension -> core_type
 
+(** [core_type_with_fresh_vars bound type_decl] will generate a new
+    core_type with unique polymorphic vars from the given type
+    declaration.  Already bound vars are passed in [bound].  It returns
+    a new core type, a list of the vars instantiated
+    and a new set of bound vars. *)
+val core_type_with_fresh_vars : string list -> type_declaration -> 
+                                core_type * core_type list * string list
+
 (** [fold_exprs ~unit fn exprs] folds [exprs] using head of [exprs] as initial
     accumulator value, or [unit] if [exprs = []].
 

--- a/src_plugins/ppx_deriving_iter.cppo.ml
+++ b/src_plugins/ppx_deriving_iter.cppo.ml
@@ -68,7 +68,7 @@ let rec expr_of_typ typ =
                        deriver (Ppx_deriving.string_of_core_type typ))
     in
     Exp.function_ cases
-  | { ptyp_desc = Ptyp_var name } -> [%expr ([%e evar ("poly_"^name)] : 'a -> unit)]
+  | { ptyp_desc = Ptyp_var name } -> [%expr ([%e evar ("poly_"^name)] : [%t Typ.var name] -> unit)]
   | { ptyp_desc = Ptyp_alias (typ, name) } ->
     [%expr fun x -> [%e evar ("poly_"^name)] x; [%e expr_of_typ typ] x]
   | { ptyp_loc } ->

--- a/src_test/test_deriving_iter.cppo.ml
+++ b/src_test/test_deriving_iter.cppo.ml
@@ -1,13 +1,42 @@
 open OUnit2
 
-type 'a btree = Node of 'a btree * 'a * 'a btree | Leaf
-[@@deriving iter]
+module T : sig
+
+  type 'a btree = Node of 'a btree * 'a * 'a btree | Leaf
+  [@@deriving iter]
+
+  (* test for #82: iter_record : ('a -> unit) -> ('b -> unit) -> ('a,'b) record -> unit) *)
+  type ('a,'b) record = { a : 'a; b : 'b }
+  [@@deriving iter]
+
+end = struct
+
+  type 'a btree = Node of 'a btree * 'a * 'a btree | Leaf
+  [@@deriving iter]
+
+  type ('a,'b) record = { a : 'a; b : 'b }
+  [@@deriving iter]
+
+end
+
+open T
 
 let test_btree ctxt =
   let lst = ref [] in
   iter_btree (fun x -> lst := x :: !lst)
              (Node (Node (Leaf, 0, Leaf), 1, Node (Leaf, 2, Leaf)));
   assert_equal [2;1;0] !lst
+
+let test_record ctxt = 
+  let lst : string list ref = ref [] in
+  lst := [];
+  iter_record (fun a -> lst := string_of_int a :: !lst) 
+              (fun b -> lst := string_of_float b :: ! lst) {a=1; b=1.2};
+  assert_equal ["1.2"; "1"] !lst;
+  lst := [];
+  iter_record (fun a -> lst := string_of_int (a+1) :: !lst) 
+              (fun b -> lst := Int64.to_string b :: ! lst) {a=3; b=4L};
+  assert_equal ["4"; "4"] !lst
 
 #if OCAML_VERSION >= (4, 03, 0)
 type 'a btreer = Node of { lft: 'a btree; elt: 'a; rgt: 'a btree } | Leaf
@@ -19,4 +48,7 @@ type 'a ty = 'a * int list
 
 let suite = "Test deriving(iter)" >::: [
     "test_btree" >:: test_btree;
+    "test_record" >:: test_record;
   ]
+
+

--- a/src_test/test_deriving_map.cppo.ml
+++ b/src_test/test_deriving_map.cppo.ml
@@ -1,71 +1,133 @@
 open OUnit2
 
+module T : sig
+  
+  type 'a btree = Node of 'a btree * 'a * 'a btree | Leaf
+  [@@deriving map, show]
+
+#if OCAML_VERSION >= (4, 03, 0)
+  type 'a btreer = Noder of { lft: 'a btree; elt: 'a; rgt: 'a btree } | Leafr
+  [@@deriving map]
+#endif
+
+  type var0 = A0 of int [@@deriving map,show]
+
+  type 'a var1 = A1 of 'a [@@deriving map,show]
+
+  type 'a var2 = A2 of 'a | B2 of int [@@deriving map,show]
+
+  type ('a,'b) var3 = A3 of 'a | B3 of bool | C3 of 'b * ('a,'b) var3 [@@deriving map,show]
+
+  type record0 = { a0 : int } [@@deriving map,show]
+
+  type 'a record1 = { a1 : 'a } [@@deriving map,show]
+
+  type 'a record2 = { a2 : 'a; b2 : int } [@@deriving map,show]
+
+  type ('a,'b) record3 = { a3 : 'a; b3 : bool; c3 : 'b } [@@deriving map,show]
+
+end = struct
+
+  type 'a btree = Node of 'a btree * 'a * 'a btree | Leaf
+  [@@deriving map, show]
+
+#if OCAML_VERSION >= (4, 03, 0)
+  type 'a btreer = Noder of { lft: 'a btree; elt: 'a; rgt: 'a btree } | Leafr
+  [@@deriving map]
+#endif
+
+  type 'a ty = 'a * int list
+  [@@deriving map]
+
+  (* variants and records with mixtures of poly/nonpoly fields *)
+
+  type var0 = A0 of int [@@deriving map,show]
+
+  type 'a var1 = A1 of 'a [@@deriving map,show]
+
+  type 'a var2 = A2 of 'a | B2 of int [@@deriving map,show]
+
+  type ('a,'b) var3 = A3 of 'a | B3 of bool | C3 of 'b * ('a,'b) var3 [@@deriving map,show]
+
+  type record0 = { a0 : int } [@@deriving map,show]
+
+  type 'a record1 = { a1 : 'a } [@@deriving map,show]
+
+  type 'a record2 = { a2 : 'a; b2 : int } [@@deriving map,show]
+
+  type ('a,'b) record3 = { a3 : 'a; b3 : bool; c3 : 'b } [@@deriving map,show]
+
+end
+
+open T
+
 let fmt_chr fmt = Format.fprintf fmt "%c"
 let fmt_flt fmt = Format.fprintf fmt "%f"
 let fmt_int fmt = Format.fprintf fmt "%d"
 let fmt_str fmt = Format.fprintf fmt "%s"
 
-type 'a btree = Node of 'a btree * 'a * 'a btree | Leaf
-[@@deriving map, show]
-
 let test_btree ctxt =
   let btree  = (Node (Node (Leaf, 0, Leaf), 1, Node (Leaf, 2, Leaf))) in
   let btree' = map_btree (fun x -> x + 1) btree in
-  assert_equal ~printer:(show_btree (fun fmt -> Format.fprintf fmt "%d"))
+  assert_equal ~printer:(show_btree fmt_int)
                (Node (Node (Leaf, 1, Leaf), 2, Node (Leaf, 3, Leaf)))
                btree'
 
-#if OCAML_VERSION >= (4, 03, 0)
-type 'a btreer = Node of { lft: 'a btree; elt: 'a; rgt: 'a btree } | Leaf
-[@@deriving map]
-#endif
+(* tests for #81 and #82 - allow non-poly fields in records and variants and
+   provide more general type for map signature:
+     ('a -> 'x) -> ... -> ('a,...) t -> ('x,...) t *)
 
-type 'a ty = 'a * int list
-[@@deriving map]
+let test_var0 ctxt =
+  assert_equal ~printer:show_var0 (A0 10) (map_var0 (A0 10))
 
-(* records *)
+let test_var1 ctxt = 
+  assert_equal ~printer:(show_var1 fmt_int) (A1 1) (map_var1 ((+)1) (A1 0));
+  assert_equal ~printer:(show_var1 fmt_str) (A1 "2") (map_var1 string_of_int (A1 2))
 
-(* no poly field *)
-type record0 = { a0 : int } [@@deriving map,show]
+let test_var2 ctxt = 
+  assert_equal ~printer:(show_var2 fmt_int) (B2 7) (map_var2 ((+)1) (B2 7));
+  assert_equal ~printer:(show_var2 fmt_int) (A2 5) (map_var2 ((+)1) (A2 4));
+  assert_equal ~printer:(show_var2 fmt_int) (A2 5) (map_var2 int_of_float (A2 5.))
+
+let test_var3 ctxt = 
+  let show,map = show_var3 fmt_int fmt_str, map_var3 ((+)1) String.uppercase in
+  assert_equal ~printer:show (A3 2) (map (A3 1));
+  assert_equal ~printer:show (B3 false) (map (B3 false));
+  assert_equal ~printer:show (C3("ABC", A3 3)) (map (C3("abc", A3 2)));
+  assert_equal ~printer:show (C3("XYZ", B3 true)) (map (C3("xyz", B3 true)));
+  let show,map = show_var3 fmt_int fmt_flt, map_var3 Char.code float_of_int in
+  assert_equal ~printer:show (A3 97) (map (A3 'a'));
+  assert_equal ~printer:show (B3 false) (map (B3 false));
+  assert_equal ~printer:show (C3(4., A3 98)) (map (C3(4, A3 'b')));
+  assert_equal ~printer:show (C3(5., B3 true)) (map (C3(5, B3 true)))
+
 let test_record0 ctxt = 
-  assert_equal ~printer:show_record0 
-    {a0=0} (map_record0 {a0=0})
+  assert_equal ~printer:show_record0 {a0=10} (map_record0 {a0=10})
 
-(* one poly field *)
-type 'a record1 = { a1 : 'a } [@@deriving map,show]
 let test_record1 ctxt = 
-  assert_equal ~printer:(show_record1 fmt_int)
-    {a1=1} (map_record1 ((+)1) {a1=0})
+  assert_equal ~printer:(show_record1 fmt_int) {a1=1} (map_record1 ((+)1) {a1=0});
+  assert_equal ~printer:(show_record1 fmt_str) {a1="2"} (map_record1 string_of_int {a1=2})
 
-(* mixture of poly / non-poly fields *)
-type 'a record2 = { a2 : 'a; b2 : int } [@@deriving map,show]
 let test_record2 ctxt = 
-  assert_equal ~printer:(show_record2 fmt_int)
-    {a2=5;b2=7} (map_record2 ((+)1) {a2=4;b2=7})
+  assert_equal ~printer:(show_record2 fmt_int) {a2=5;b2=7} (map_record2 ((+)1) {a2=4;b2=7});
+  assert_equal ~printer:(show_record2 fmt_int) {a2=5;b2=0} (map_record2 int_of_float {a2=5.;b2=0})
 
-type ('a,'b) record3 = { a3 : 'a; b3 : bool; c3 : 'b } [@@deriving map,show]
 let test_record3 ctxt = 
   assert_equal ~printer:(show_record3 fmt_int fmt_str)
-    {a3=5;b3=false;c3="ABC"} (map_record3 ((+)1) String.uppercase {a3=4;b3=false;c3="abc"})
-
-(* change types *)
-let test_record3_poly ctxt =
-  let recd  = {a3='a';b3=true;c3=4} in
-  let mapd = map_record3 Char.code float_of_int recd in
-  let expt  = {a3=97;b3=true;c3=4.} in
-  assert_bool
-    (Printf.sprintf "(map %s = %s) <> %s"
-      (show_record3 fmt_chr fmt_int recd)
-      (show_record3 fmt_int fmt_flt mapd)
-      (show_record3 fmt_int fmt_flt expt))
-    (mapd = expt)
+    {a3=5;b3=false;c3="ABC"} (map_record3 ((+)1) String.uppercase {a3=4;b3=false;c3="abc"});
+  assert_equal ~printer:(show_record3 fmt_int fmt_flt)
+    {a3=97;b3=false;c3=4.} (map_record3 Char.code float_of_int {a3='a';b3=false;c3=4})
 
 let suite = "Test deriving(map)" >::: [
     "test_btree" >:: test_btree;
+    "test_var0" >:: test_var0;
+    "test_var1" >:: test_var1;
+    "test_var2" >:: test_var2;
+    "test_var3" >:: test_var3;
     "test_record0" >:: test_record0;
     "test_record1" >:: test_record1;
     "test_record2" >:: test_record2;
     "test_record3" >:: test_record3;
-    "test_record3_poly" >:: test_record3_poly;
   ]
+
 


### PR DESCRIPTION
The signature generated for `map` was less general than the actual
implementation ie

```
type 'a t = ...
val map : ('a -> 'a) -> 'a t -> 'a t
```

as opposed to

```
val map : ('a -> 'b) -> 'a t -> 'b t
```

A bit of new machinary is added to ppx_deriving.ml to support this
`core_type_with_fresh_vars`.

For `iter` the signature was actually more general than the
implementation

```
type ('a,'b) t = ...
val iter : ('a -> unit) -> ('b -> unit) -> ('a,'b) t -> unit
```

whereas the implementation gave

```
val iter : ('a -> unit) -> ('a -> unit) -> ('a,'a) t -> unit
```

This was due to a type constraint on the `Ptyp_var` that forced
all the poly arg functions to the same type.