### PR TITLE
Change Arg api to use Result.result

### DIFF
--- a/_tags
+++ b/_tags
@@ -2,8 +2,7 @@ true: warn(@5@8@10@11@12@14@23@24@26@29@40), bin_annot, safe_string, debug, cppo
 "data": -traverse
 
 "src": include
-<src/ppx_deriving_runtime*>: package(result)
-<src/*.{ml,mli,byte,native}>: package(dynlink), package(compiler-libs.common), package(ppx_tools.metaquot)
+<src/*.{ml,mli,byte,native}>: package(dynlink), package(compiler-libs.common), package(ppx_tools.metaquot), package(result)
 <src/ppx_deriving_main.{byte,native}>: linkall
 <src_plugins/*.{ml,mli}>: package(compiler-libs.common), package(ppx_tools.metaquot)
 


### PR DESCRIPTION
Previously it would use a polymorphic variant version of result. This is
no longer necessary as OCaml now has a standard result type.

The sanitize change will come in a different PR

Fix #75