### PR TITLE
Parameterize sanitize over a module

### DIFF
--- a/src/ppx_deriving.cppo.ml
+++ b/src/ppx_deriving.cppo.ml
@@ -152,8 +152,11 @@ let quote ~quoter expr =
   quoter.next_id <- quoter.next_id + 1;
   [%expr [%e evar name] ()]
 
-let sanitize ?(quoter=create_quoter ()) expr =
-  let body = [%expr (let open! Ppx_deriving_runtime in [%e expr]) [@ocaml.warning "-A"]] in
+let sanitize ?(module_=Lident "Ppx_deriving_runtime") ?(quoter=create_quoter ()) expr =
+  let body =
+    Exp.open_
+      ~attrs:[mkloc "ocaml.warning" !Ast_helper.default_loc, PStr [%str "-A"]]
+      Override { txt=module_; loc=(!Ast_helper.default_loc) } expr in
   match quoter.bindings with
   | [] -> body
   | bindings -> Exp.let_ Nonrecursive bindings body

--- a/src/ppx_deriving.mli
+++ b/src/ppx_deriving.mli
@@ -154,10 +154,12 @@ val create_quoter : unit -> quoter
     that [sanitize] provides. *)
 val quote : quoter:quoter -> expression -> expression
 
-(** [sanitize quoter expr] wraps [expr] in a way that ensures that the contents of
-    {!Ppx_deriving_runtime} and {!Pervasives}, as well as the identifiers in
-    expressions returned by [quote] are in scope, and returns the wrapped expression. *)
-val sanitize : ?quoter:quoter -> expression -> expression
+(** [sanitize module_ quoter expr] wraps [expr] in a way that ensures that the
+    contents of [module_] and {!Pervasives}, as well as the identifiers in
+    expressions returned by [quote] are in scope, and returns the wrapped
+    expression. [module_] defaults to !{Ppx_deriving_runtime} if it's not
+    provided*)
+val sanitize : ?module_:Longident.t -> ?quoter:quoter -> expression -> expression
 
 (** [with_quoter fn] ≡
     [fun fn a -> let quoter = create_quoter () in sanitize ~quoter (fn quoter a)] *)


### PR DESCRIPTION
Sanitize can wrap an expression using a provided module name. If a
module name isn't provided, `Ppx_deriving_runtime` will be used as the
default.

@Drup can you verify the loc handling?