### PR TITLE
minor: per-constructor, per-field location in equality code

### DIFF
--- a/src_plugins/ppx_deriving_eq.cppo.ml
+++ b/src_plugins/ppx_deriving_eq.cppo.ml
@@ -148,7 +148,8 @@ let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
     | Ptype_abstract, Some manifest -> expr_of_typ quoter manifest
     | Ptype_variant constrs, _ ->
       let cases =
-        (constrs |> List.map (fun { pcd_name = { txt = name }; pcd_args } ->
+        (constrs |> List.map (fun { pcd_name = { txt = name }; pcd_args; pcd_loc } ->
+          with_default_loc pcd_loc @@ fun () ->
           match pcd_args with
           | Pcstr_tuple(typs) ->
             exprn quoter typs |>
@@ -168,7 +169,8 @@ let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
       [%expr fun lhs rhs -> [%e Exp.match_ [%expr lhs, rhs] cases]]
     | Ptype_record labels, _ ->
       let exprs =
-        labels |> List.map (fun { pld_name = { txt = name }; pld_type; pld_attributes } ->
+        labels |> List.map (fun { pld_name = { txt = name }; pld_type; pld_attributes; pld_loc } ->
+          with_default_loc pld_loc @@ fun () ->
           (* combine attributes of type and label *)
           let attrs =  pld_type.ptyp_attributes @ pld_attributes in
           let pld_type = {pld_type with ptyp_attributes=attrs} in


### PR DESCRIPTION
I'm currently trying to use ppx_deriving in a codebase that uses some
GADTs, and running into the problem that the generated code does not
type-check. One extra difficulty is that the locations in the
generated code are wrong. For example, consider

    type _ expr =
    | Int : int -> int expr
    | Prod : 'a expr * 'b expr -> ('a * 'b) expr
    [@@deriving eq]

the current implementation will report

    type _ expr =
    ^^^^^^^^^^^^^
    File "foo.ml", line 1, characters 0-98:
    Error: This pattern matches values of type (ex#0 * ex#1) expr
           but a pattern was expected which matches values of type int expr
           Type ex#0 * ex#1 is not compatible with type int

after the present commit, one gets instead

    | Prod : 'a expr * 'b expr -> ('a * 'b) expr
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "foo.ml", line 3, characters 0-44:
    Error: This pattern matches values of type (ex#0 * ex#1) expr
           but a pattern was expected which matches values of type int expr
           Type ex#0 * ex#1 is not compatible with type int

which allows to pinpoint the problematic constructor, and thus orient
ourselves in the -dsource output to further understand the typing error.

Note that the handling of location is extremely heavy-handed and
rather inelegant (global side-effect with rollback). The fault for
this seems to lie in ppx-tools that does not follow Ast_helper's
convention of having ?loc parameters.