### PR TITLE
Really remove duplicate in free type variables.

### DIFF
--- a/src/ppx_deriving.cppo.ml
+++ b/src/ppx_deriving.cppo.ml
@@ -266,13 +266,10 @@ let free_vars_in_core_type typ =
         ) rows |> List.concat |> List.concat
     | _ -> assert false
   in
-  let rec uniq acc lst =
-    match lst with
-    | a :: b :: lst when a = b -> uniq acc (b :: lst)
-    | x :: lst -> uniq (x :: acc) lst
-    | [] -> acc
-  in
-  List.rev (uniq [] (free_in typ))
+  let uniq lst =
+    let module StringSet = Set.Make(String) in
+    lst |> StringSet.of_list |> StringSet.elements in
+  free_in typ |> uniq
 
 let var_name_of_int i =
   let letter = "abcdefghijklmnopqrstuvwxyz" in


### PR DESCRIPTION
Example:

    type (_, 'a, 'b) split_list =
    | Foo of unit
    [@@deriving eq]

Before this commit:

    let rec (equal_split_list :
              'a 'b 'a 'b 'a 'b .
                ('a -> 'a -> Ppx_deriving_runtime.bool) ->
                  ('b -> 'b -> Ppx_deriving_runtime.bool) ->
                    (_,'a,'b) split_list ->
                      (_,'a,'b) split_list -> Ppx_deriving_runtime.bool)
      = ...

After this commit:

    let rec (equal_split_list :
              'a 'b .
                ('a -> 'a -> Ppx_deriving_runtime.bool) ->
                  ('b -> 'b -> Ppx_deriving_runtime.bool) ->
                    (_,'a,'b) split_list ->
                      (_,'a,'b) split_list -> Ppx_deriving_runtime.bool)
      = ...