### PR TITLE
Support deriving from module type declarations.

### DIFF
--- a/src/ppx_deriving.mli
+++ b/src/ppx_deriving.mli
@@ -27,10 +27,16 @@ type deriver = {
                    type_declaration list -> structure;
   type_ext_str : options:(string * expression) list -> path:string list ->
                    type_extension -> structure;
+  module_type_decl_str : options:(string * expression) list ->
+                          path:string list ->
+                          module_type_declaration -> structure;
   type_decl_sig : options:(string * expression) list -> path:string list ->
                    type_declaration list -> signature;
   type_ext_sig : options:(string * expression) list -> path:string list ->
                   type_extension -> signature;
+  module_type_decl_sig : options:(string * expression) list ->
+                          path:string list ->
+                          module_type_declaration -> signature;
 }
 
 (** [register deriver] registers [deriver] according to its [name] field. *)
@@ -48,6 +54,12 @@ val create :
                     type_declaration list -> structure) ->
   ?type_decl_sig: (options:(string * expression) list -> path:string list ->
                     type_declaration list -> signature) ->
+  ?module_type_decl_str: (options:(string * expression) list ->
+                           path:string list ->
+                           module_type_declaration -> structure) ->
+  ?module_type_decl_sig: (options:(string * expression) list ->
+                           path:string list ->
+                           module_type_declaration -> signature) ->
   unit -> deriver
 
 (** [lookup name] looks up a deriver called [name]. *)


### PR DESCRIPTION
I could use an extension of the deriving interface to allow deriving definitions from module types.  The derived definitions would typically be a structure of the given signature or a functor producing or depending on it, though it could be regular functions involving first-class modules of the signature.  My current use-case is to generate the RPC client and server parts for a Thrift service.
