### PR TITLE
Add support for loading findlib packages instead of just files

### DIFF
--- a/_tags
+++ b/_tags
@@ -3,6 +3,7 @@ true: warn(@5@8@10@11@12@14@23@24@26@29@40), bin_annot, safe_string, debug, cppo
 
 "src": include
 <src/*.{ml,mli,byte,native}>: package(dynlink), package(compiler-libs.common), package(ppx_tools.metaquot), package(result)
+<src/ppx_deriving_main.{ml,mli,byte,native}>: package(findlib.dynload), predicate(ppx_driver)
 <src/ppx_deriving_main.{byte,native}>: linkall
 <src_plugins/*.{ml,mli}>: package(compiler-libs.common), package(ppx_tools.metaquot)
 

--- a/opam
+++ b/opam
@@ -23,7 +23,7 @@ build-doc: [
 ]
 depends: [
   "ocamlbuild" {build}
-  "ocamlfind"  {build & >= "1.5.4"}
+  "ocamlfind"  {build & >= "1.6.0"}
   "cppo"       {build}
   "ppx_tools"  {>= "4.02.3"}
   "result"


### PR DESCRIPTION
This patch add support for loading packages instead of just files. This makes the use of libraries inside ppx\_deriving plugins a lot easier.

To load a package, one must pass `package:package-name` to ppx\_deriving. The package must also use the `plugin` variable (or the deprecated `archive(plugin)` which is generated by oasis).

In the end the META of a ppx\_deriving plugin that is using this feature must look like:

```
package "show" (
  version = "%{version}%"
  description = "[@@deriving show]"
  requires(-ppx_driver) = "ppx_deriving"
  ppxopt(-ppx_driver) = "ppx_deriving,package:ppx_deriving.show"
  requires(ppx_driver) = "ppx_deriving.api"
  archive(ppx_driver, byte) = "ppx_deriving_show.cma"
  archive(ppx_driver, native) = "ppx_deriving_show.cmxa"
  plugin(ppx_driver, byte) = "ppx_deriving_show.cma"
  plugin(ppx_driver, native) = "ppx_deriving_show.cmxs"
  exists_if = "ppx_deriving_show.cma"
)
```