### PR TITLE
Remove pervasives when appropriate.

### DIFF
--- a/src/ppx_deriving.mli
+++ b/src/ppx_deriving.mli
@@ -218,6 +218,14 @@ val attr_warning: expression -> attribute
     lexical order. *)
 val free_vars_in_core_type : core_type -> string list
 
+(** [remove_pervasives ~deriver typ] removes the leading "Pervasives."
+    module name in longidents.
+    Type expressions marked with [\[\@nobuiltin\]] are ignored.
+
+    The name of the deriving plugin should be passed as [deriver]; it is used
+    in error messages. *)
+val remove_pervasives : deriver:string -> core_type -> core_type
+
 (** [fresh_var bound] returns a fresh variable name not present in [bound].
     The name is selected in alphabetical succession. *)
 val fresh_var : string list -> string

--- a/src_plugins/ppx_deriving_create.cppo.ml
+++ b/src_plugins/ppx_deriving_create.cppo.ml
@@ -49,6 +49,7 @@ let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
       in
       List.fold_left (fun accum { pld_name = { txt = name }; pld_type; pld_attributes } ->
         let attrs = pld_attributes @ pld_type.ptyp_attributes in
+        let pld_type = Ppx_deriving.remove_pervasives ~deriver pld_type in
         match attr_default attrs with
         | Some default -> Exp.fun_ (Label.optional name) (Some (Ppx_deriving.quote ~quoter default))
                                    (pvar name) accum
@@ -99,6 +100,7 @@ let sig_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
       in
       List.fold_left (fun accum { pld_name = { txt = name; loc }; pld_type; pld_attributes } ->
         let attrs = pld_type.ptyp_attributes @ pld_attributes in
+        let pld_type = Ppx_deriving.remove_pervasives ~deriver pld_type in
         match attr_default attrs with
         | Some _ -> Typ.arrow (Label.optional name) (wrap_predef_option pld_type) accum
         | None ->

--- a/src_plugins/ppx_deriving_eq.cppo.ml
+++ b/src_plugins/ppx_deriving_eq.cppo.ml
@@ -60,6 +60,7 @@ and exprl quoter typs =
     app (expr_of_typ quoter typ) [evar (argl `lhs n); evar (argl `rhs n)])
 
 and expr_of_typ quoter typ =
+  let typ = Ppx_deriving.remove_pervasives ~deriver typ in
   let expr_of_typ = expr_of_typ quoter in
   match attr_equal typ.ptyp_attributes with
   | Some fn -> Ppx_deriving.quote quoter fn

--- a/src_plugins/ppx_deriving_fold.cppo.ml
+++ b/src_plugins/ppx_deriving_fold.cppo.ml
@@ -37,7 +37,7 @@ let rec expr_of_typ typ =
   | { ptyp_desc = Ptyp_constr ({ txt = lid }, args) } ->
     let builtin = not (attr_nobuiltin typ.ptyp_attributes) in
     begin match builtin, typ with
-    | true, [%type: [%t? typ] ref] -> [%expr fun x -> [%e expr_of_typ typ] !x]
+    | true, [%type: [%t? typ] ref] -> [%expr fun acc x -> [%e expr_of_typ typ] acc !x]
     | true, [%type: [%t? typ] list] ->
       [%expr Ppx_deriving_runtime.List.fold_left [%e expr_of_typ typ]]
     | true, [%type: [%t? typ] array] ->

--- a/src_plugins/ppx_deriving_fold.cppo.ml
+++ b/src_plugins/ppx_deriving_fold.cppo.ml
@@ -31,6 +31,7 @@ let pconstrrec name fields = pconstr name [precord ~closed:Closed fields]
 let reduce_acc a b = [%expr let acc = [%e a] in [%e b]]
 
 let rec expr_of_typ typ =
+  let typ = Ppx_deriving.remove_pervasives ~deriver typ in
   match typ with
   | _ when Ppx_deriving.free_vars_in_core_type typ = [] -> [%expr fun acc _ -> acc]
   | { ptyp_desc = Ptyp_constr ({ txt = lid }, args) } ->

--- a/src_plugins/ppx_deriving_iter.cppo.ml
+++ b/src_plugins/ppx_deriving_iter.cppo.ml
@@ -29,6 +29,7 @@ let pattl labels = List.map (fun { pld_name = { txt = n } } -> n, pvar (argl n))
 let pconstrrec name fields = pconstr name [precord ~closed:Closed fields]
 
 let rec expr_of_typ typ =
+  let typ = Ppx_deriving.remove_pervasives ~deriver typ in
   match typ with
   | _ when Ppx_deriving.free_vars_in_core_type typ = [] -> [%expr fun _ -> ()]
   | { ptyp_desc = Ptyp_constr _ } ->

--- a/src_plugins/ppx_deriving_make.cppo.ml
+++ b/src_plugins/ppx_deriving_make.cppo.ml
@@ -37,7 +37,7 @@ let is_optional { pld_name = { txt = name }; pld_type; pld_attributes } =
   | Some _ -> true
   | None ->
     attr_split attrs ||
-    (match pld_type with
+    (match Ppx_deriving.remove_pervasives ~deriver pld_type with
      | [%type: [%t? _] list]
      | [%type: [%t? _] option] -> true
      | _ -> false)
@@ -64,6 +64,7 @@ let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
       in
       List.fold_left (fun accum { pld_name = { txt = name }; pld_type; pld_attributes } ->
         let attrs = pld_attributes @ pld_type.ptyp_attributes in
+        let pld_type = Ppx_deriving.remove_pervasives ~deriver pld_type in
         match attr_default attrs with
         | Some default -> Exp.fun_ (Label.optional name) (Some (Ppx_deriving.quote ~quoter default))
                                    (pvar name) accum
@@ -115,6 +116,7 @@ let sig_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
       in
       List.fold_left (fun accum { pld_name = { txt = name; loc }; pld_type; pld_attributes } ->
         let attrs = pld_type.ptyp_attributes @ pld_attributes in
+        let pld_type = Ppx_deriving.remove_pervasives ~deriver pld_type in
         match attr_default attrs with
         | Some _ -> Typ.arrow (Label.optional name) (wrap_predef_option pld_type) accum
         | None ->

--- a/src_plugins/ppx_deriving_map.cppo.ml
+++ b/src_plugins/ppx_deriving_map.cppo.ml
@@ -30,6 +30,7 @@ let pconstrrec name fields = pconstr name [precord ~closed:Closed fields]
 let  constrrec name fields =  constr name [ record                fields]
 
 let rec expr_of_typ typ =
+  let typ = Ppx_deriving.remove_pervasives ~deriver typ in
   match typ with
   | _ when Ppx_deriving.free_vars_in_core_type typ = [] -> [%expr fun x -> x]
   | { ptyp_desc = Ptyp_constr _ } ->

--- a/src_plugins/ppx_deriving_ord.cppo.ml
+++ b/src_plugins/ppx_deriving_ord.cppo.ml
@@ -63,6 +63,7 @@ and expr_of_typ quoter typ =
   match attr_compare typ.ptyp_attributes with
   | Some fn -> Ppx_deriving.quote quoter fn
   | None ->
+    let typ = Ppx_deriving.remove_pervasives ~deriver typ in
     match typ with
     | [%type: _] -> [%expr fun _ _ -> 0]
     | { ptyp_desc = Ptyp_constr _ } ->

--- a/src_plugins/ppx_deriving_show.cppo.ml
+++ b/src_plugins/ppx_deriving_show.cppo.ml
@@ -81,6 +81,7 @@ let rec expr_of_typ quoter typ =
           [%e expr_of_typ typ] x; true) false x);
         Format.fprintf fmt [%e str finish];]
     in
+    let typ = Ppx_deriving.remove_pervasives ~deriver typ in
     match typ with
     | [%type: _] -> [%expr fun _ -> Format.pp_print_string fmt "_"]
     | { ptyp_desc = Ptyp_arrow _ } ->

--- a/src_test/test_deriving_eq.cppo.ml
+++ b/src_test/test_deriving_eq.cppo.ml
@@ -13,7 +13,8 @@ type a6 = bool       [@@deriving eq]
 type a7 = char       [@@deriving eq]
 type a8 = string     [@@deriving eq]
 type a9 = bytes      [@@deriving eq]
-type r  = int ref    [@@deriving eq]
+type r1 = int ref    [@@deriving eq]
+type r2 = int Pervasives.ref [@@deriving eq]
 type l  = int list   [@@deriving eq]
 type a  = int array  [@@deriving eq]
 type o  = int option [@@deriving eq]
@@ -27,7 +28,13 @@ let test_arr ctxt =
   assert_equal ~printer true (equal_a [||] [||]);
   assert_equal ~printer true (equal_a [|1|] [|1|]);
   assert_equal ~printer false (equal_a [||] [|1|]);
-  assert_equal ~printer false (equal_a [|2|] [|1|]);
+  assert_equal ~printer false (equal_a [|2|] [|1|])
+
+let test_ref1 ctxt =
+  assert_equal ~printer true (equal_r1 (ref 0) (ref 0))
+
+let test_ref2 ctxt =
+  assert_equal ~printer true (equal_r2 (ref 0) (ref 0))
 
 type v = Foo | Bar of int * string | Baz of string [@@deriving eq]
 
@@ -136,6 +143,8 @@ let test_result ctxt =
 let suite = "Test deriving(eq)" >::: [
     "test_simple"        >:: test_simple;
     "test_array"         >:: test_arr;
+    "test_ref1"          >:: test_ref1;
+    "test_ref2"          >:: test_ref2;
     "test_custom"        >:: test_custom;
     "test_placeholder"   >:: test_placeholder;
     "test_mrec"          >:: test_mrec;

--- a/src_test/test_deriving_fold.cppo.ml
+++ b/src_test/test_deriving_fold.cppo.ml
@@ -7,6 +7,13 @@ let test_btree ctxt =
   let btree  = (Node (Node (Leaf, 3, Leaf), 1, Node (Leaf, 2, Leaf))) in
   assert_equal ~printer:string_of_int 6 (fold_btree (+) 0 btree)
 
+type 'a reflist = 'a Pervasives.ref list
+[@@deriving fold]
+
+let test_reflist ctxt =
+  let reflist  = [ ref 3 ; ref 2 ; ref 1 ] in
+  assert_equal ~printer:string_of_int 6 (fold_reflist (+) 0 reflist)
+
 #if OCAML_VERSION >= (4, 03, 0)
 type 'a btreer = Node of { lft: 'a btree; elt: 'a; rgt: 'a btree } | Leaf
 [@@deriving fold]
@@ -24,5 +31,6 @@ let test_result ctxt =
 
 let suite = "Test deriving(fold)" >::: [
   "test_btree" >:: test_btree;
-  "test_result" >:: test_result
+  "test_result" >:: test_result;
+  "test_reflist" >:: test_reflist;
 ]

--- a/src_test/test_deriving_iter.cppo.ml
+++ b/src_test/test_deriving_iter.cppo.ml
@@ -9,12 +9,18 @@ module T : sig
   type ('a,'b) record = { a : 'a; b : 'b }
   [@@deriving iter]
 
+  type 'a reflist = 'a Pervasives.ref list
+  [@@deriving iter]
+
 end = struct
 
   type 'a btree = Node of 'a btree * 'a * 'a btree | Leaf
   [@@deriving iter]
 
   type ('a,'b) record = { a : 'a; b : 'b }
+  [@@deriving iter]
+
+  type 'a reflist = 'a Pervasives.ref list
   [@@deriving iter]
 
 end
@@ -27,16 +33,22 @@ let test_btree ctxt =
              (Node (Node (Leaf, 0, Leaf), 1, Node (Leaf, 2, Leaf)));
   assert_equal [2;1;0] !lst
 
-let test_record ctxt = 
+let test_record ctxt =
   let lst : string list ref = ref [] in
   lst := [];
-  iter_record (fun a -> lst := string_of_int a :: !lst) 
+  iter_record (fun a -> lst := string_of_int a :: !lst)
               (fun b -> lst := string_of_float b :: ! lst) {a=1; b=1.2};
   assert_equal ["1.2"; "1"] !lst;
   lst := [];
-  iter_record (fun a -> lst := string_of_int (a+1) :: !lst) 
+  iter_record (fun a -> lst := string_of_int (a+1) :: !lst)
               (fun b -> lst := Int64.to_string b :: ! lst) {a=3; b=4L};
   assert_equal ["4"; "4"] !lst
+
+let test_reflist ctxt =
+  let lst = ref [] in
+  iter_reflist (fun x -> lst := x :: !lst)
+               [ ref 0 ; ref 1 ; ref 2 ] ;
+  assert_equal [2;1;0] !lst
 
 #if OCAML_VERSION >= (4, 03, 0)
 type 'a btreer = Node of { lft: 'a btree; elt: 'a; rgt: 'a btree } | Leaf
@@ -58,5 +70,6 @@ let test_iter_res ctxt =
 let suite = "Test deriving(iter)" >::: [
   "test_btree" >:: test_btree;
   "test_record" >:: test_record;
+  "test_reflist" >:: test_reflist;
   "test_iter_res" >:: test_iter_res
 ]

--- a/src_test/test_deriving_ord.cppo.ml
+++ b/src_test/test_deriving_ord.cppo.ml
@@ -13,7 +13,6 @@ type a6 = bool       [@@deriving ord]
 type a7 = char       [@@deriving ord]
 type a8 = string     [@@deriving ord]
 type a9 = bytes      [@@deriving ord]
-type r  = int ref    [@@deriving ord]
 type l  = int list   [@@deriving ord]
 type a  = int array  [@@deriving ord]
 type o  = int option [@@deriving ord]
@@ -109,6 +108,18 @@ let test_ord_result ctx =
   assert_equal ~printer (-1) (compare_res0 (Ok ()) (Error ()));
   assert_equal ~printer 1 (compare_res0 (Error ()) (Ok ()))
 
+type r1 = int ref [@@deriving ord]
+let test_ref1 ctxt =
+  assert_equal ~printer (-1) (compare_r1 (ref 0) (ref 1));
+  assert_equal ~printer (0) (compare_r1 (ref 0) (ref 0));
+  assert_equal ~printer (1) (compare_r1 (ref 1) (ref 0))
+
+type r2 = int Pervasives.ref [@@deriving ord]
+let test_ref2 ctxt =
+  assert_equal ~printer (-1) (compare_r2 (ref 0) (ref 1));
+  assert_equal ~printer (0) (compare_r2 (ref 0) (ref 0));
+  assert_equal ~printer (1) (compare_r2 (ref 1) (ref 0))
+
 type es =
   | ESBool of bool
   | ESString of string
@@ -160,6 +171,8 @@ let suite = "Test deriving(ord)" >::: [
     "test_placeholder"   >:: test_placeholder;
     "test_mrec"          >:: test_mrec;
     "test_mrec2"         >:: test_mrec2;
+    "test_ref1"          >:: test_ref1;
+    "test_ref2"          >:: test_ref2;
     "test_std_shadowing" >:: test_std_shadowing;
     "test_poly_app"      >:: test_poly_app;
     "test_ord_result"    >:: test_ord_result

--- a/src_test/test_deriving_show.cppo.ml
+++ b/src_test/test_deriving_show.cppo.ml
@@ -12,6 +12,8 @@ type a7 = char       [@@deriving show]
 type a8 = string     [@@deriving show]
 type a9 = bytes      [@@deriving show]
 type r  = int ref    [@@deriving show]
+type r2 = int Pervasives.ref [@@deriving show]
+type r3 = int Pervasives.ref ref [@@deriving show]
 type l  = int list   [@@deriving show]
 type a  = int array  [@@deriving show]
 type o  = int option [@@deriving show]
@@ -28,6 +30,8 @@ let test_alias ctxt =
   assert_equal ~printer "\"foo\"" (show_a8 "foo");
   assert_equal ~printer "\"foo\"" (show_a9 (Bytes.of_string "foo"));
   assert_equal ~printer "ref (1)" (show_r (ref 1));
+  assert_equal ~printer "ref (1)" (show_r2 (ref 1));
+  assert_equal ~printer "ref (ref (1))" (show_r3 (ref (ref 1)));
   assert_equal ~printer "[1; 2; 3]" (show_l [1;2;3]);
   assert_equal ~printer "[|1; 2; 3|]" (show_a [|1;2;3|]);
   assert_equal ~printer "(Some 1)" (show_o (Some 1));


### PR DESCRIPTION
This removes the leading `Pervasives` module when matching on built-in types. It solves issues with ppx_import on 4.03 (where types are fully qualified).