### PR TITLE
Fix build on windows (mingw)

### DIFF
--- a/pkg/build.ml
+++ b/pkg/build.ml
@@ -7,8 +7,14 @@ let () =
   output_string oc (if Env.native then "<*.ml>: ppx_native" else "<*.ml>: ppx_byte");
   close_out oc
 
+let quote_parens s =
+  if Sys.win32 then
+    s
+  else
+    "'" ^ s ^ "'"
+
 let ocamlbuild =
-  "ocamlbuild -use-ocamlfind -classic-display -plugin-tag 'package(cppo_ocamlbuild)'"
+  "ocamlbuild -use-ocamlfind -classic-display -plugin-tag " ^ quote_parens "package(cppo_ocamlbuild)"
 
 let () =
   Pkg.describe "ppx_deriving" ~builder:(`Other (ocamlbuild, "_build")) [


### PR DESCRIPTION
When trying to build `ppx_deriving` on windows (mingw, not cygwin), the build fails with the following error message:

```
Plugin tag "'package(cppo_ocamlbuild)'", line 1, characters 0-1:
Lexing error: Not a valid parametrized tag.
```

The reason is the build command defined in `pkg/build.ml`:

```ocaml
let ocamlbuild =
  "ocamlbuild -use-ocamlfind -classic-display -plugin-tag 'package(cppo_ocamlbuild)'"
```

It is passed to `Sys.command` by `topkg`, and it is passed to `system`, which will use `cmd.exe` to execute it. Its behaviour with regards to quoting is very different from POSIX shells, and it will pass them to them to the program in a literal way.

Removing the simple quotes makes it work on mingw, but makes it fail on unix. I haven't found a way to quote it in a way that will please both, so this requires adding a conditional unfortunately.

Here is a patch that does this if you are interested in supporting this configuration.

Let me know what you think!

:sparkles: Thanks! :sparkles: