### PR TITLE
Monomorphize compare function for builtin types

### DIFF
--- a/src_plugins/ppx_deriving_ord.cppo.ml
+++ b/src_plugins/ppx_deriving_ord.cppo.ml
@@ -75,7 +75,8 @@ and expr_of_typ quoter typ =
               | [%type: int64] | [%type: Int64.t] | [%type: nativeint]
               | [%type: Nativeint.t] | [%type: float] | [%type: bool]
               | [%type: char] | [%type: string] | [%type: bytes]) ->
-        [%expr Pervasives.compare]
+        let compare_fn = [%expr fun (a:[%t typ]) b -> Pervasives.compare a b] in
+        Ppx_deriving.quote quoter compare_fn
       | true, [%type: [%t? typ] ref] ->
         [%expr fun a b -> [%e expr_of_typ typ] !a !b]
       | true, [%type: [%t? typ] list]  ->


### PR DESCRIPTION
The `[%ord: int]` expression expands to `Pervasives.compare`. Since this function is polymorphic, it may be used with other types. For example, the following expression typechecks:

```.ocaml
([%ord: int] : string -> string -> int)
```

This adds a type constraint on the `Pervasives.compare` call so that it becomes monomorphic. This is also more consistent with how this case is handled in the `eq` plugin.

Let me know what you think. Thanks!