### PR TITLE
Show plugin: add option to skip module path

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,24 @@ It is also possible to use `[@polyprinter]`. The difference is that for a type `
 
 The function `fprintf` is locally defined in the printer.
 
+By default all constructors are printed with prefix which is dot-separated filename and module path. For example
+``` ocaml
+# module X = struct type t = C [@@deriving show] end;;
+...
+# X.(show C);;
+- : Ppx_deriving_runtime.string = "X.C"
+```
+
+This code will create printers which return the string `X.C`, `X` is a module path and `C` is a constructor name. File's name is omitted in the toplevel. To skip all module paths the one needs to derive show with option `with_path` (which defaults to `true`)
+
+``` ocaml
+# module X = struct type t = C [@@deriving show { with_path = false }] end;;
+...
+# X.(show C);;
+- : Ppx_deriving_runtime.string = "C"
+```
+
+
 Plugins: eq and ord
 -------------------
 

--- a/src_test/test_deriving_show.cppo.ml
+++ b/src_test/test_deriving_show.cppo.ml
@@ -214,6 +214,17 @@ let test_variant_printer ctxt =
   assert_equal ~printer
     "fourth: 8 4" (show_variant_printer (Fourth(8,4)))
 
+type no_full    = NoFull   of int [@@deriving show { with_path = false }]
+type with_full  = WithFull of int [@@deriving show { with_path = true  }]
+module WithFull = struct
+  type t = A of int [@@deriving show ]
+end
+let test_paths_printer ctxt =
+  assert_equal ~printer "(NoFull 1)"   (show_no_full   (NoFull 1));
+  assert_equal ~printer "(Test_deriving_show.WithFull 1)" (show_with_full (WithFull 1));
+  assert_equal ~printer "(Test_deriving_show.WithFull.A 1)" (WithFull.show (WithFull.A 1));
+  ()
+
 let suite = "Test deriving(show)" >::: [
     "test_alias"           >:: test_alias;
     "test_variant"         >:: test_variant;
@@ -232,5 +243,6 @@ let suite = "Test deriving(show)" >::: [
     "test_std_shadowing"   >:: test_std_shadowing;
     "test_poly_app"        >:: test_poly_app;
     "test_variant_printer" >:: test_variant_printer;
+    "test_paths"           >:: test_paths_printer;
     "test_result"          >:: test_result
   ]


### PR DESCRIPTION
We were kind of bothered that `show` adds filename as prefix for all constructors. So we added very straightforward way to workaround this.  What was the expected way to hack this?

@eucpp