### PR TITLE
Support result and not just Result.result

### DIFF
--- a/src_plugins/ppx_deriving_eq.cppo.ml
+++ b/src_plugins/ppx_deriving_eq.cppo.ml
@@ -98,7 +98,8 @@ and expr_of_typ quoter typ =
           | None, None -> true
           | Some a, Some b -> [%e expr_of_typ typ] a b
           | _ -> false]
-      | true, [%type: ([%t? ok_t], [%t? err_t]) Result.result] ->
+      | true, ([%type: ([%t? ok_t], [%t? err_t]) result] |
+               [%type: ([%t? ok_t], [%t? err_t]) Result.result]) ->
         [%expr fun x y ->
           match x, y with
           | Result.Ok a, Result.Ok b -> [%e expr_of_typ ok_t] a b

--- a/src_plugins/ppx_deriving_fold.cppo.ml
+++ b/src_plugins/ppx_deriving_fold.cppo.ml
@@ -44,7 +44,8 @@ let rec expr_of_typ typ =
       [%expr Ppx_deriving_runtime.Array.fold_left [%e expr_of_typ typ]]
     | true, [%type: [%t? typ] option] ->
       [%expr fun acc -> function None -> acc | Some x -> [%e expr_of_typ typ] acc x]
-    | true, [%type: ([%t? ok_t], [%t? err_t]) Result.result] ->
+    | true, ([%type: ([%t? ok_t], [%t? err_t]) result] |
+             [%type: ([%t? ok_t], [%t? err_t]) Result.result]) ->
       [%expr
         fun acc -> function
         | Result.Ok ok -> [%e expr_of_typ ok_t] acc ok

--- a/src_plugins/ppx_deriving_map.cppo.ml
+++ b/src_plugins/ppx_deriving_map.cppo.ml
@@ -42,7 +42,8 @@ let rec expr_of_typ ?decl typ =
       [%expr Ppx_deriving_runtime.Array.map [%e expr_of_typ ?decl typ]]
     | true, [%type: [%t? typ] option] ->
       [%expr function None -> None | Some x -> Some ([%e expr_of_typ ?decl typ] x)]
-    | true, [%type: ([%t? ok_t], [%t? err_t]) Result.result] ->
+    | true, ([%type: ([%t? ok_t], [%t? err_t]) result] |
+             [%type: ([%t? ok_t], [%t? err_t]) Result.result]) ->
       [%expr
         function
         | Result.Ok ok -> Result.Ok ([%e expr_of_typ ?decl ok_t] ok)

--- a/src_plugins/ppx_deriving_ord.cppo.ml
+++ b/src_plugins/ppx_deriving_ord.cppo.ml
@@ -105,7 +105,8 @@ and expr_of_typ quoter typ =
           | Some a, Some b -> [%e expr_of_typ typ] a b
           | None, Some _ -> -1
           | Some _, None -> 1]
-      | true, [%type: ([%t? ok_t], [%t? err_t]) Result.result] ->
+      | true, ([%type: ([%t? ok_t], [%t? err_t]) result] |
+               [%type: ([%t? ok_t], [%t? err_t]) Result.result]) ->
         [%expr fun x y ->
           match x, y with
           | Result.Error a, Result.Error b -> [%e expr_of_typ err_t] a b

--- a/src_plugins/ppx_deriving_show.cppo.ml
+++ b/src_plugins/ppx_deriving_show.cppo.ml
@@ -125,7 +125,8 @@ let rec expr_of_typ quoter typ =
             Format.pp_print_string fmt "(Some ";
             [%e expr_of_typ typ] x;
             Format.pp_print_string fmt ")"]
-      | true, [%type: ([%t? ok_t],[%t? err_t]) Result.result] ->
+      | true, ([%type: ([%t? ok_t], [%t? err_t]) result] |
+               [%type: ([%t? ok_t], [%t? err_t]) Result.result]) ->
         [%expr
           function
           | Result.Ok ok ->

--- a/src_test/test_deriving_eq.cppo.ml
+++ b/src_test/test_deriving_eq.cppo.ml
@@ -133,9 +133,17 @@ end
 type 'a std_clash = 'a List.t option
 [@@deriving eq]
 
+#if OCAML_VERSION >= (4, 03, 0)
 let test_result ctxt =
-  let eq = [%eq: (string, int) Result.result] in
+  let eq = [%eq: (string, int) result] in
+  assert_equal ~printer true (eq (Ok "ttt") (Ok "ttt"));
+  assert_equal ~printer false (eq (Ok "123") (Error 123));
+  assert_equal ~printer false (eq (Error 123) (Error 0))
+#endif
+
+let test_result_result ctxt =
   let open Result in
+  let eq = [%eq: (string, int) result] in
   assert_equal ~printer true (eq (Ok "ttt") (Ok "ttt"));
   assert_equal ~printer false (eq (Ok "123") (Error 123));
   assert_equal ~printer false (eq (Error 123) (Error 0))
@@ -151,6 +159,9 @@ let suite = "Test deriving(eq)" >::: [
     "test_mut_rec"       >:: test_mut_rec;
     "test_std_shadowing" >:: test_std_shadowing;
     "test_poly_app"      >:: test_poly_app;
-    "test_result"        >:: test_result
+#if OCAML_VERSION >= (4, 03, 0)
+    "test_result"        >:: test_result;
+#endif
+    "test_result_result" >:: test_result_result;
   ]
 

--- a/src_test/test_deriving_fold.cppo.ml
+++ b/src_test/test_deriving_fold.cppo.ml
@@ -22,15 +22,27 @@ type 'a btreer = Node of { lft: 'a btree; elt: 'a; rgt: 'a btree } | Leaf
 type 'a ty = 'a * int list
 [@@deriving fold]
 
-type ('a, 'b) res = ('a, 'b) Result.result [@@deriving fold]
+#if OCAML_VERSION >= (4, 03, 0)
+type ('a, 'b) res = ('a, 'b) result [@@deriving fold]
 
 let test_result ctxt =
   let f = fold_res (+) (-) in
+  assert_equal ~printer:string_of_int 1 (f 0 (Ok 1));
+  assert_equal ~printer:string_of_int (-1) (f 0 (Error 1))
+#endif
+
+type ('a, 'b) result_res = ('a, 'b) Result.result [@@deriving fold]
+
+let test_result_result ctxt =
+  let f = fold_result_res (+) (-) in
   assert_equal ~printer:string_of_int 1 (f 0 (Result.Ok 1));
   assert_equal ~printer:string_of_int (-1) (f 0 (Result.Error 1))
 
 let suite = "Test deriving(fold)" >::: [
   "test_btree" >:: test_btree;
+#if OCAML_VERSION >= (4, 03, 0)
   "test_result" >:: test_result;
+#endif
+  "test_result_result" >:: test_result_result;
   "test_reflist" >:: test_reflist;
 ]

--- a/src_test/test_deriving_map.cppo.ml
+++ b/src_test/test_deriving_map.cppo.ml
@@ -141,13 +141,24 @@ let test_pvar3 ctxt =
   assert_equal ~printer:show `F (map `F);
   assert_equal ~printer:show `G (map `G)
 
-type 'a result0 = ('a, bool) Result.result [@@deriving show, map]
+#if OCAML_VERSION >= (4, 03, 0)
+type 'a result0 = ('a, bool) result [@@deriving show,map]
 
 let test_map_result ctxt =
   let f = map_result0 succ in
   let printer = show_result0 fmt_int in
-  assert_equal ~printer (Result.Ok 10) (f (Result.Ok 9));
-  assert_equal ~printer (Result.Error true) (f (Result.Error true))
+  assert_equal ~printer (Ok 10) (f (Ok 9));
+  assert_equal ~printer (Error true) (f (Error true))
+#endif
+
+type 'a result_result0 = ('a, bool) Result.result [@@deriving show,map]
+
+let test_map_result_result ctxt =
+  let open Result in
+  let f = map_result_result0 succ in
+  let printer = show_result_result0 fmt_int in
+  assert_equal ~printer (Ok 10) (f (Ok 9));
+  assert_equal ~printer (Error true) (f (Error true))
 
 let suite = "Test deriving(map)" >::: [
     "test_btree" >:: test_btree;
@@ -160,7 +171,10 @@ let suite = "Test deriving(map)" >::: [
     "test_record2" >:: test_record2;
     "test_record3" >:: test_record3;
     "test_pvar3" >:: test_pvar3;
-    "test_map_result" >:: test_map_result
+#if OCAML_VERSION >= (4, 03, 0)
+    "test_map_result" >:: test_map_result;
+#endif
+    "test_map_result_result" >:: test_map_result_result;
   ]
 
 

--- a/src_test/test_deriving_ord.cppo.ml
+++ b/src_test/test_deriving_ord.cppo.ml
@@ -101,7 +101,15 @@ let test_mrec2 ctxt =
   assert_equal ~printer (-1) (compare_e ce1 ce2);
   assert_equal ~printer (1) (compare_e ce2 ce1)
 
+#if OCAML_VERSION >= (4, 03, 0)
 let test_ord_result ctx =
+  let compare_res0 = [%ord: (unit, unit) result] in
+  assert_equal ~printer 0 (compare_res0 (Ok ()) (Ok ()));
+  assert_equal ~printer (-1) (compare_res0 (Ok ()) (Error ()));
+  assert_equal ~printer 1 (compare_res0 (Error ()) (Ok ()))
+#endif
+
+let test_ord_result_result ctx =
   let compare_res0 = [%ord: (unit, unit) Result.result] in
   let open Result in
   assert_equal ~printer 0 (compare_res0 (Ok ()) (Ok ()));
@@ -175,5 +183,8 @@ let suite = "Test deriving(ord)" >::: [
     "test_ref2"          >:: test_ref2;
     "test_std_shadowing" >:: test_std_shadowing;
     "test_poly_app"      >:: test_poly_app;
-    "test_ord_result"    >:: test_ord_result
+#if OCAML_VERSION >= (4, 03, 0)
+    "test_ord_result"    >:: test_ord_result;
+#endif
+    "test_ord_result_result" >:: test_ord_result_result;
   ]

--- a/src_test/test_deriving_show.cppo.ml
+++ b/src_test/test_deriving_show.cppo.ml
@@ -153,15 +153,29 @@ let test_mrec ctxt =
   let e1 =  B { x = 12; r = F 16 } in
   assert_equal ~printer "(Test_deriving_show.B\n   { Test_deriving_show.x = 12; r = (Test_deriving_show.F 16) })" (show_foo e1)
 
-type i_has_result = I_has of (bool, string) Result.result [@@deriving show]
+
+#if OCAML_VERSION >= (4, 03, 0)
+type i_has_result = I_has of (bool, string) result [@@deriving show]
 
 let test_result ctxt =
   assert_equal ~printer "(Ok 100)"
-    ([%show: (int, bool) Result.result] (Result.Ok 100));
+    ([%show: (int, bool) result] (Ok 100));
   assert_equal ~printer "(Test_deriving_show.I_has (Ok true))"
-    (show_i_has_result (I_has (Result.Ok true)));
+    (show_i_has_result (I_has (Ok true)));
   assert_equal ~printer "(Test_deriving_show.I_has (Error \"err\"))"
-    (show_i_has_result (I_has (Result.Error "err")))
+    (show_i_has_result (I_has (Error "err")))
+#endif
+
+type i_has_result_result = I_has of (bool, string) Result.result [@@deriving show]
+
+let test_result_result ctxt =
+  let open Result in
+  assert_equal ~printer "(Ok 100)"
+    ([%show: (int, bool) result] (Result.Ok 100));
+  assert_equal ~printer "(Test_deriving_show.I_has (Ok true))"
+    (show_i_has_result_result (I_has (Ok true)));
+  assert_equal ~printer "(Test_deriving_show.I_has (Error \"err\"))"
+    (show_i_has_result_result (I_has (Error "err")))
 
 type es =
   | ESBool of (bool [@nobuiltin])
@@ -244,5 +258,8 @@ let suite = "Test deriving(show)" >::: [
     "test_poly_app"        >:: test_poly_app;
     "test_variant_printer" >:: test_variant_printer;
     "test_paths"           >:: test_paths_printer;
-    "test_result"          >:: test_result
+#if OCAML_VERSION >= (4, 03, 0)
+    "test_result"          >:: test_result;
+#endif
+    "test_result_result"   >:: test_result_result;
   ]


### PR DESCRIPTION
On OCaml 4.03.0+, this enables you to write
```ocaml
[%show: (string, string) result] (Ok "hello")
```
instead of being limited to:
```ocaml
[%show: (string, string) Result.result] (Ok "hello")
```
This should work for all standard plugins, not just "show".